### PR TITLE
Fix session authorization code, for real

### DIFF
--- a/site/src/app.js
+++ b/site/src/app.js
@@ -31,6 +31,20 @@ app.use((state, emitter) => {
   state.secure = false
   state.serverRequiresAuthorization = false
 
+  Object.defineProperty(state, 'sessionAuthorized', {
+    get: function() {
+      if (state.serverRequiresAuthorization) {
+        return state._sessionAuthorized
+      } else {
+        return true
+      }
+    },
+
+    set: function(value) {
+      state._sessionAuthorized = value
+    }
+  })
+
   // publish state for debugging/experimenting as well
   window.state = state
 

--- a/site/src/components/sidebar.js
+++ b/site/src/components/sidebar.js
@@ -347,16 +347,7 @@ const store = (state, emitter) => {
     if (session.user) {
       state.session = { id: sessionID, user: session.user }
 
-      // If the server requires authorization, we'll set the sessionAuthorized
-      // state value to whether or not the logged in user is authorized (which
-      // is a property on that user object). If the server doesn't require
-      // authorization, we'll just set sessionAuthorized to true, since
-      // acting as though we're authorized is what we want.
-      if (state.serverRequiresAuthorization) {
-        state.sessionAuthorized = session.user.authorized
-      } else {
-        state.sessionAuthorized = true
-      }
+      state.sessionAuthorized = true
 
       emitter.emit('login')
     } else {


### PR DESCRIPTION
This fixes session authorization being borked by making the `sessionAuthorized` state into a "magic" property. It will *always* equal true when the server does not require authorization, regardless of whatever it was actually set to. (This is stored internally on the state as `_sessionAuthorized`; see the diff for how it works.)

I'm not certain, but I'm fairly sure this fixes emotes not being loaded immediately, which in turn makes messages actually be rendered (rather than not be rendered because emotes are yet to be fetched).