### PR TITLE
Immediately try to fetch emotes when switching to a server

### DIFF
--- a/site/src/app.js
+++ b/site/src/app.js
@@ -97,6 +97,8 @@ app.use((state, emitter) => {
       // wait for the WebSocket to connect, because a bunch of things
       // basically don't function without it
       await new Promise(resolve => state.ws.once('open', resolve))
+
+      emitter.emit('emotes.fetch')
     }
 
     emitter.emit('routeready')


### PR DESCRIPTION
This will gracefully not do anything if the server requires authorization (because [this](https://github.com/decent-chat/decent/blob/4088b9a7d4f2ae1d0b60caf45494de4a3de46280/site/src/components/srv-settings/emotes.js#L15-L16)); if the server *doesn't* require authorization, emotes will immediately be loaded, which will permit messages to be rendered.