### PR TITLE
Centralize route authentication

### DIFF
--- a/api.js
+++ b/api.js
@@ -1359,6 +1359,8 @@ module.exports = async function attachAPI(app, {wss, db}) {
   ])
 
   app.post('/api/delete-sessions', [
+    ...middleware.loadVarFromBody('sessionIDs'),
+
     // No verification ("are you the owner of this session ID" etc), because
     // if you know the session ID, you obviously have power over it!
 

--- a/api.js
+++ b/api.js
@@ -513,32 +513,37 @@ module.exports = async function attachAPI(app, {wss, db}) {
       next()
     },
 
+    (request, response, next) => {
+      // First we check the POST body for the session ID (if it's a POST
+      // request). If we don't find anything, we check the query URL, then
+      // the headers (X-Session-ID). If we still don't find a session ID and
+      // one is required - shouldVerify - we'll say none was given
+      // and prevent the user from proceeding.
+      //
+      // See the 'authorization' section in the API docs.
+      let sessionID
+      if (request.method === 'POST' && 'sessionID' in request.body) {
+        sessionID = request.body.sessionID
+      } else if ('sessionID' in request.query) {
+        sessionID = request.query.sessionID
+      } else if ('x-session-id' in request.headers) {
+        sessionID = request.headers['x-session-id'] // All headers are lowercase.
+      } else if (request[middleware.vars].shouldVerify) {
+        // No session ID given - just quit here.
+        response.status(403).end(JSON.stringify({
+          error: 'missing sessionID field - not authorized to access API'
+        }))
+        return
+      }
+
+      // We'll save the session ID as a middleware-var so we can use it
+      // in the upcoming requests.
+      Object.assign(request[middleware.vars], {sessionID})
+
+      next()
+    },
+
     ...middleware.runIfVarExists('shouldVerify', [
-      (request, response, next) => {
-        // First we check the POST body for the session ID (if it's a POST
-        // request). If we don't find anything, we check the query URL.
-        // If we still don't find a session ID, we'll say none was given
-        // and prevent the user from proceeding.
-        let sessionID
-        if (request.method === 'POST' && 'sessionID' in request.body) {
-          sessionID = request.body.sessionID
-        } else if ('sessionID' in request.query) {
-          sessionID = request.query.sessionID
-        } else {
-          // No session ID given - just quit here.
-          response.status(403).end(JSON.stringify({
-            error: 'missing sessionID field - not authorized to access API'
-          }))
-          return
-        }
-
-        // We'll save the session ID as a middleware-var so we can use it
-        // in the upcoming requests.
-        Object.assign(request[middleware.vars], {sessionID})
-
-        next()
-      },
-
       // No need to rewrite the wheel - we have a fancy way of guessing where
       // we might get the session ID, but we can use it just like we always
       // do (with our normal middleware functions).
@@ -618,7 +623,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
   // TODO: delete old images
   app.post('/api/upload-image', [
-    ...middleware.loadVarFromQuery('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
     //...middleware.requireBeAdmin('sessionUser'),
     (req, res) => uploadSingleImage(req, res, err => {
@@ -643,7 +647,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
   ])
 
   app.post('/api/server-settings', [
-    ...middleware.loadVarFromBody('sessionID'),
     ...middleware.loadVarFromBody('patch'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
     ...middleware.requireBeAdmin('sessionUser'),
@@ -694,7 +697,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
   app.post('/api/send-message', [
     ...middleware.loadVarFromBody('text'),
     ...middleware.loadVarFromBody('channelID'),
-    ...middleware.loadVarFromBody('sessionID'),
     ...middleware.getChannelFromID('channelID', '_'), // To verify that it exists.
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
 
@@ -728,7 +730,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
   app.post('/api/pin-message', [
     ...middleware.loadVarFromBody('messageID'),
-    ...middleware.loadVarFromBody('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
     ...middleware.requireBeAdmin('sessionUser'),
     ...middleware.getMessageFromID('messageID', 'message'),
@@ -764,7 +765,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
   app.post('/api/add-message-reaction', [
     ...middleware.loadVarFromBody('reactionCode'),
-    ...middleware.loadVarFromBody('sessionID'),
     ...middleware.loadVarFromBody('messageID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
     ...middleware.getMessageFromID('messageID', 'message'),
@@ -819,7 +819,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
   ])
 
   app.post('/api/edit-message', [
-    ...middleware.loadVarFromBody('sessionID'),
     ...middleware.loadVarFromBody('messageID'),
     ...middleware.loadVarFromBody('text'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
@@ -854,7 +853,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
   ])
 
   app.post('/api/delete-message', [
-    ...middleware.loadVarFromBody('sessionID'),
     ...middleware.loadVarFromBody('messageID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
     ...middleware.getMessageFromID('messageID', 'message'),
@@ -894,7 +892,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
   app.post('/api/create-channel', [
     ...middleware.loadVarFromBody('name'),
-    ...middleware.loadVarFromBody('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
     ...middleware.requireBeAdmin('sessionUser'),
     ...middleware.requireNameValid('name'),
@@ -929,7 +926,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
   app.post('/api/rename-channel', [
     ...middleware.loadVarFromBody('channelID'),
     ...middleware.loadVarFromBody('name'),
-    ...middleware.loadVarFromBody('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
     ...middleware.requireBeAdmin('sessionUser'),
     ...middleware.requireNameValid('name'),
@@ -960,7 +956,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
   app.post('/api/delete-channel', [
     ...middleware.loadVarFromBody('channelID'),
-    ...middleware.loadVarFromBody('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
     ...middleware.requireBeAdmin('sessionUser'),
     ...middleware.getChannelFromID('channelID', '_'), // To verify the channel exists.
@@ -987,7 +982,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
   app.get('/api/channel/:channelID', [
     ...middleware.loadVarFromParams('channelID'),
-    ...middleware.loadVarFromQuery('sessionID', false), // Optional - provides more data
     ...middleware.getChannelFromID('channelID', 'channel'),
     ...middleware.runIfVarExists('sessionID',
       middleware.getSessionUserFromID('sessionID', 'sessionUser')
@@ -1004,7 +998,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
   ])
 
   app.get('/api/channel-list', [
-    ...middleware.loadVarFromQuery('sessionID', false), // Optional - provides more data
     ...middleware.runIfVarExists('sessionID',
       middleware.getSessionUserFromID('sessionID', 'sessionUser')
     ),
@@ -1074,7 +1067,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
   app.post('/api/mark-channel-as-read', [
     ...middleware.loadVarFromBody('channelID'),
-    ...middleware.loadVarFromBody('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
     ...middleware.getChannelFromID('channelID', '_'), // To verify that it exists
 
@@ -1091,7 +1083,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
   app.get('/api/channel-is-read', [
     ...middleware.loadVarFromQuery('channelID'),
-    ...middleware.loadVarFromQuery('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
 
     async (request, response) => {
@@ -1173,7 +1164,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
   app.post('/api/account-settings', [
     ...middleware.loadVarFromBody('email'),
-    ...middleware.loadVarFromBody('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'user'),
 
     async (request, response) => {
@@ -1194,11 +1184,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
   app.get('/api/user-list', [
     ...middleware.runIfCondition(() => shouldUseAuthorization, [
-      ...middleware.loadVarFromQuery('sessionID', false),
-      ...middleware.runIfVarExists('sessionID',
-        middleware.getSessionUserFromID('sessionID', 'sessionUser')
-      ),
-
       async (request, response) => {
         const { sessionUser } = request[middleware.vars]
         const isAdmin = sessionUser && sessionUser.permissionLevel === 'admin'
@@ -1328,7 +1313,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
     },
 
     ...middleware.loadVarFromBody('userID'),
-    ...middleware.loadVarFromBody('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
     ...middleware.requireBeAdmin('sessionUser'),
     ...middleware.getUserFromID('userID', '_')
@@ -1375,8 +1359,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
   ])
 
   app.post('/api/delete-sessions', [
-    ...middleware.loadVarFromBody('sessionIDs'),
-
     // No verification ("are you the owner of this session ID" etc), because
     // if you know the session ID, you obviously have power over it!
 
@@ -1404,7 +1386,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
   ])
 
   app.get('/api/user-session-list', [
-    ...middleware.loadVarFromQuery('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
 
     async (request, response) => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,14 @@
 <h1 align='center'> 🎈 Decent API documentation </h1>
 
-The project's API is publically available to anybody with access to the actual server on which it is hosted. [HTTP endpoints](#http-endpoints) provide virtually all methods of interaction from the client towards the server, while [WebSocket events](#websocket-events) let the server send messages to the client. Common data received from the server (such as users or messages) always follows [particular formats](#objects). It would be wise to understand and expect [authorization](#authorization) to be required. All endpoints, unless General information which doesn't particularly fit anywhere else can be found in the appendix-esque section [Etc](#etc), and any questions one might have can be posted to the [issue tracker](https://github.com/towerofnix/decent/issues).
+Communicating with the API
+* [HTTP endpoints](#http-endpoints) provide virtually all methods of interaction from the client towards the server
+* [WebSocket events](#websocket-events) let the server send messages to the client.
+
+Common data received from the server (such as users or messages) always follows [particular formats](#objects).
+
+It would be wise to understand and expect [authorization](#authorization) to be required. **All endpoints, unless specified, follow the server-wide authentication rule.**
+
+General information which doesn't particularly fit anywhere else can be found in the appendix-esque section [Etc](#etc), and any questions one might have can be posted to the [issue tracker](https://github.com/decent-chat/decent/issues).
 
 ## HTTP endpoints
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,9 @@ These are all the paths (think: URLs, `/api/user/:userID`) which can be fetched 
 
 ### GET `/api`
 
-Returns `{decent: true, message, repository}`, where `message` and `repository` are hard-coded strings for Humans to read. Also returns the status code [`418`](https://en.wikipedia.org/wiki/Hyper_Text_Coffee_Pot_Control_Protocol). Use this endpoint to verify that a given hostname is actually a Decent server. Does not require [authorization](#authorization).
+- [Authentication](#authentication): never required.
+
+Returns `{decent: true, message, repository}`, where `message` and `repository` are hard-coded strings for Humans to read. Also returns the status code [`418`](https://en.wikipedia.org/wiki/Hyper_Text_Coffee_Pot_Control_Protocol). Use this endpoint to verify that a given hostname is actually a Decent server
 
 ### GET `/api/server-settings`
 
@@ -18,7 +20,7 @@ Returns an object representing server-specific settings.
 
 - Parameters:
   * `patch`: (via data; object) an object acting as the dictionary to apply.
-  * `sessionID`: (via data; string) the user's session ID. **The user must be an admin.**
+- [Authentication](#authentication): always required. **The requesting user must be an admin.**
 
 Takes the parameter `patch` and overwrites each of the specified properties according to the corresponding values. Only previously existing settings will be overwritten (no new properties will be made). Returns the result status of each item; for example, if two properties are given, and the first has a valid key while the second's key doesn't exist, the change specified by the first will still be applied, even though the second failed.
 
@@ -29,8 +31,8 @@ Takes the parameter `patch` and overwrites each of the specified properties acco
 ### POST `/api/account-settings`
 
 - Parameters:
-  * `sessionID`: (via data; string) the user's session ID. Must be valid.
   * `email`: (via data; string/null) the new email address of the user.
+- [Authentication](#authentication): always required.
 
 Returns `{success: true, avatarURL}`, where `avatarURL` is a string URL (usually pointing to [Libravatar](https://www.libravatar.org/)) to be used as the user's profile picture.
 
@@ -47,7 +49,7 @@ Returns an object `{useAuthorization, authorizationMessage}`, where `useAuthoriz
 - Parameters:
   * `text`: (via data; string) the text to send in the message. Typically, clients will interpret message text as markdown.
   * `channelID`: (via data; string) the ID of the channel to which the message will be sent. The channel has to exist.
-  * `sessionID`: (via data; string) the user's session ID. This must be a valid session ID.
+- [Authentication](#authentication): always required.
 
 Sends a message. Returns an object `{success: true, messageID}` if successful, where `messageID` is the unique ID of the new message, and emits a [`received chat message`](#from-server-received-chat-message) WebSocket event.
 
@@ -63,7 +65,7 @@ Returns a [message object](#message-object) corresponding to the given message I
 - Parameters:
   * `text`: (via data; string) the new text content.
   * `messageID`: (via data; string) the message ID. The message has to exist.
-  * `sessionID`: (via data; string) the user's session ID. **The user must own the message.**
+- [Authentication](#authentication): always required. **The user must own the message.**
 
 Overwrites the text content of an existing message and attaches an "edited" date to it. Returns `{success: true}` if successful, and emits an [`edited chat message`](#from-server-edited-chat-message) WebSocket event.
 
@@ -71,19 +73,19 @@ Overwrites the text content of an existing message and attaches an "edited" date
 
 - Parameters:
   * `messageID`: (via data; string) the ID of the message to be pinned. The message has to exist.
-  * `sessionID`: (via data; string) the user's session ID. **The user must be an admin.**
+- [Authentication](#authentication): always required. **The user must be an admin.**
 
 Adds a message to its channel's pinned messages list. Returns `{success: true}` if succesful.
 
 ### POST `/api/add-message-reaction`
 
-This endpoint is unstable. See discussion in [GitHub issue #21](https://github.com/towerofnix/bantisocial/issues/21).
+This endpoint is unstable. See discussion in [GitHub issue #21](https://github.com/decent-chat/decent/issues/21).
 
 ### POST `/api/create-channel`
 
 - Parameters:
   * `name`: (via data; string) the name of the channel. This must be a [valid name](#valid-names), and there must not already be a channel with the same name.
-  * `sessionID`: (via data; string) the user's session ID. **The user must be an admin.**
+- [Authentication](#authentication): always required. **The user must be an admin.**
 
 Creates a channel (which will immediately be able to receive messages). Returns `{success: true, channelID}` if successful, where `channelID` is the unique ID of the channel, and emits a [`created new channel`](#from-server-created-new-channel) WebSocket event.
 
@@ -91,7 +93,8 @@ Creates a channel (which will immediately be able to receive messages). Returns 
 
 - Parameters:
   * `channelID`: (via URL path) the unique ID of the channel. The channel has to exist.
-  * `sessionID`: (via query; optional) the session ID of the user. [Extra data](#channel-object) will be returned if given.
+- [Authentication](#authentication): optional, unless the server requires [authorization](#authorization).
+  * [Extra data](#channel-object) will be returned if given.
 
 Returns `{success: true, channel}` if successful, where `channel` is a [(detailed) channel object](#channel-object) corresponding to the channel with the given ID.
 
@@ -100,7 +103,7 @@ Returns `{success: true, channel}` if successful, where `channel` is a [(detaile
 - Parameters:
   * `name`: (via data; string) the new name to be given to the channel. Must be a [valid name](#valid-names).
   * `channelID`: (via data; string) the unique ID of the channel to be renamed. The channel has to exist.
-  * `sessionID`: (via data; string) the session ID of the user. **The user must be an admin.**
+- [Authentication](#authentication): always required. **The requesting user must be an admin.**
 
 Changes the name of a channel. Returns `{success: true}` if successful, and emits a [`renamed channel`](#from-server-renamed-channel) WebSocket event.
 
@@ -108,14 +111,13 @@ Changes the name of a channel. Returns `{success: true}` if successful, and emit
 
 - Parameters:
   * `channelID`: (via data; string) the unique ID of the channel to be deleted. The channel has to exist.
-  * `sessionID`: (via data; string) the session ID of the user. **The user must be an admin.**
+- [Authentication](#authentication): always required. **The requesting user must be an admin.**
 
 Deletes a channel and any messages in it. Returns `{success: true}` if successful, and emits a [`deleted channel`](#from-server-deleted-channel) WebSocket event.
 
 ### GET `/api/channel-list`
 
-- Parameters:
-  * `sessionID`: (via query; optional) the session ID of the user. [Extra data](#channel-object) will be returned if given.
+- [Authentication](#authentication): always required. **The requesting user must be an admin.**
 
 Returns `{success: true, channels}`, where channels is an array of [(brief) channel objects](#channel-object) for each channel on the server.
 
@@ -133,14 +135,15 @@ Returns `{success: true, messages}`, where messages is an array of the 50 most r
 - Parameters:
   * `username`: (via body; string) the username to use. The username must not already be taken, and must be a [valid name](#valid-names).
   * `password`: (via body; string) the password to use. The password must be at least 6 characters long.
+- [Authentication](#authentication): never required.
 
-Registers a new user. The given password is passed to `/api/register` as a plain string, and is stored in the database as a bcrypt-hashed and salted string (and not in any plain text form). Returns `{success: true, user}` if successful, where `user` is the new user as a [user object](#user-object). Does not require [authorization](#authorization).
+Registers a new user. The given password is passed to `/api/register` as a plain string, and is stored in the database as a bcrypt-hashed and salted string (and not in any plain text form). Returns `{success: true, user}` if successful, where `user` is the new user as a [user object](#user-object).
 
 ### POST `/api/authorize-user`
 
 - Parameters:
   * `userID`: (via data; string) the unique ID of the user to be authorized.
-  * `sessionID`: (via data; string) the session ID of the user who is requesting this endpoint. **The requesting user must be an admin.**
+- [Authentication](#authentication): always required. **The requesting user must be an admin.**
 
 [Authorizes](#authorization) the given user. Returns `{success: true}` if successful. Doesn't do anything (returns an error) if authorization is disabled.
 
@@ -148,7 +151,7 @@ Registers a new user. The given password is passed to `/api/register` as a plain
 
 - Parameters:
   * `userID`: (via data; string) the unique ID of the user to be deauthorized. This must not be the requesting user (you can't deauthorize yourself).
-  * `sessionID`: (via data; string) the session ID of the user who is requesting this endpoint. **The requesting user must be an admin.**
+- [Authentication](#authentication): always required. **The requesting user must be an admin.**
 
 [Deauthorizes](#authorization) the given user. Returns `{success: true}` if successful. Doesn't do anything (returns an error) if authorization is disabled.
 
@@ -175,15 +178,17 @@ Returns `{available}`, where `available` is a boolean set to whether or not the 
 - Parameters:
   * `username`: (via body; string) the username to log in as. There must be a user with this name.
   * `password`: (via body; string) the password to use. This must (when hashed) match the user's password.
+- [Authentication](#authentication): never required.
 
-Attempts to log in as a user, creating a new session. Returns `{success: true, sessionID}` if successful, where `sessionID` is the ID of the newly-created session. Does not require [authorization](#authorization).
+Attempts to log in as a user, creating a new session. Returns `{success: true, sessionID}` if successful, where `sessionID` is the ID of the newly-created session.
 
 ### GET `/api/session/:sessionID`
 
 - Parameters:
   * `sessionID`: (via URL path) the session ID to fetch. The session must exist.
+- [Authentication](#authentication): never required. Should, however, be provided in the URL.
 
-Returns `{success: true, user}` if successful, where `user` is a [user object](#user-object) of the user which the session represents. This endpoint is useful when grabbing information about the logged in user (e.g. at the startup of a client program, which may display the logged in user's username in a status bar). Does not require [authorization](#authorization).
+Returns `{success: true, user}` if successful, where `user` is a [user object](#user-object) of the user which the session represents. This endpoint is useful when grabbing information about the logged in user (e.g. at the startup of a client program, which may display the logged in user's username in a status bar).
 
 ### POST `/api/delete-sessions`
 
@@ -194,8 +199,7 @@ Deletes the given sessions (using their IDs will no longer work). Passing just o
 
 ### GET `/api/user-session-list`
 
-- Parameters:
-  * `sessionID`: (via body; string) the session ID to use. The session must exist.
+- [Authentication](#authentication): always required.
 
 Returns `{success: true, sessions}` if successful, where `sessions` is an array of [(brief) session objects](#session-object). All sessions which are logged into the same user as the given session (via `sessionID`) are returned.
 
@@ -252,7 +256,7 @@ A message sent by an author, to a particular channel.
 * `text`: (string) the text content of the message. This is not processed; it's whatever the author entered, verbatim. This should typically be interpreted as markdown.
 * `date`: (number) the date when the message was sent (actually when it was saved into the database).
 * `editDate`: (number or null) the date when the message was most recently edited, or null, if the message has never been edited.
-* `reactions`: future storage for reactions. The reaction API is not stable yet (see [GitHub issue #21](https://github.com/towerofnix/bantisocial/issues/21)).
+* `reactions`: future storage for reactions. The reaction API is not stable yet (see [GitHub issue #21](https://github.com/decent-chat/decent/issues/21)).
 
 ### User Object
 
@@ -314,9 +318,7 @@ Authorization is a server property and can only be enabled via the actual comman
 
 When authorization is enabled for the first time, only admins will be verified. When a user is made to be an admin through the command line (`make-admin`), they will also be authorized. Users can then be authorized via the [`authorize-user`](#post-apiauthorize-user) endpoint (in the official client, there's a dedicated settings page for this). Users can be deauthorized using [`deauthorize-user`](#post-apideauthorize-user).
 
-When a request is made to the API of a server which requires authorization, the server searches for a session ID given in the request. (First it checks for a `sessionID` field in POST data; if that's not found, it checks the `?sessionID` query field.) If no session ID is found, or the session ID is for a user who isn't authorized, the request is immediately ended with status code 403 and an error. Otherwise, the request is processed as normal.
-
-What the above *basically* means is that you should always send `sessionID` (either in the POST body or the URL query), or else servers with authorization enabled won't let you do much of anything.
+See [authentication](#authentication) for details on how to authenticate. What this *basically* means is that you should always send `sessionID` (either in the POST body, the URL query string, or as a header), or else servers with authorization enabled won't let you do much of anything.
 
 Note that some endpoints do not require authorization:
 
@@ -324,6 +326,15 @@ Note that some endpoints do not require authorization:
 * [`POST /api/login`](#post-apilogin)
 * [`POST /api/register`](#post-apiregister)
 * [`GET /api/session/:sessionID`](#get-apisessionsessionid)
+
+### Authentication:
+
+When a request is made to the API, the server searches for a session ID given in the request using:
+* `sessionID` in POST data
+* `?sessionID` in query string
+* `X-Session-ID` header
+
+If the server requires [authorization](#authorization) and the session ID could not be found or pointed to an unauthenticated user, the request is immediately terminated with a 403 and error message. We recommend simply sending the `X-Session-ID` header with _all_ requests, even on non-authorization-requiring servers.
 
 ### Dates
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 <h1 align='center'> 🎈 Decent API documentation </h1>
 
-The project's API is publically available to anybody with access to the actual server on which it is hosted. [HTTP endpoints](#http-endpoints) provide virtually all methods of interaction from the client towards the server, while [WebSocket events](#websocket-events) let the server send messages to the client. Common data received from the server (such as users or messages) always follows [particular formats](#objects). It would be wise to understand and expect [authorization](#authorization) to be required. All endpoints, unless s General information which doesn't particularly fit anywhere else can be found in the appendix-esque section [Etc](#etc), and any questions one might have can be posted to the [issue tracker](https://github.com/towerofnix/decent/issues).
+The project's API is publically available to anybody with access to the actual server on which it is hosted. [HTTP endpoints](#http-endpoints) provide virtually all methods of interaction from the client towards the server, while [WebSocket events](#websocket-events) let the server send messages to the client. Common data received from the server (such as users or messages) always follows [particular formats](#objects). It would be wise to understand and expect [authorization](#authorization) to be required. All endpoints, unless General information which doesn't particularly fit anywhere else can be found in the appendix-esque section [Etc](#etc), and any questions one might have can be posted to the [issue tracker](https://github.com/towerofnix/decent/issues).
 
 ## HTTP endpoints
 
@@ -340,7 +340,7 @@ When a request is made to the API, the server searches for a session ID given in
 * `?sessionID` in query string
 * `X-Session-ID` header
 
-If the server requires [authorization](#authorization) and the session ID could not be found or pointed to an unauthenticated user, the request is immediately terminated with a 403 and error message. We recommend simply sending the `X-Session-ID` header with _all_ requests, even on non-authorization-requiring servers.
+If the server requires [authorization](#authorization) and the session ID could not be found or pointed to an unauthenticated user, the request is immediately terminated with a 403 and error message. It's likely simpler to just send the `X-Session-ID` header with _all_ requests, even on non-authorization-requiring servers.
 
 ### Dates
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,16 +1,18 @@
 <h1 align='center'> 🎈 Decent API documentation </h1>
 
-The project's API is publicly available to anybody with access to the actual server on which it is hosted. [HTTP endpoints](#http-endpoints) provide virtually all methods of interaction from the client towards the server, while [WebSocket events](#websocket-events) let the server send messages to the client. Common data received from the server (such as users or messages) always follows [particular formats](#objects). It would be wise to understand and expect [authorization](#authorization) to be required. General information which doesn't particularly fit anywhere else can be found in the appendix-esque section [Etc](#etc), and any questions one might have can be posted to the [issue tracker](https://github.com/towerofnix/decent/issues).
+The project's API is publically available to anybody with access to the actual server on which it is hosted. [HTTP endpoints](#http-endpoints) provide virtually all methods of interaction from the client towards the server, while [WebSocket events](#websocket-events) let the server send messages to the client. Common data received from the server (such as users or messages) always follows [particular formats](#objects). It would be wise to understand and expect [authorization](#authorization) to be required. All endpoints, unless s General information which doesn't particularly fit anywhere else can be found in the appendix-esque section [Etc](#etc), and any questions one might have can be posted to the [issue tracker](https://github.com/towerofnix/decent/issues).
 
 ## HTTP endpoints
 
 These are all the paths (think: URLs, `/api/user/:userID`) which can be fetched with plain old HTTP requests. All POST endpoints expect bodies encoded in **JSON**, and every endpoint will respond with a stringified JSON object.
 
+If [authorization](#authorization) is required by the server, **all endpoints will require [authentication](#authentication) unless otherwise stated**. TL;DR: pass your session ID as the `X-Session-ID` header, as `sessionID` in POST data, or as `sessionID` in the URL query string.
+
 ### GET `/api`
 
 - [Authentication](#authentication): never required.
 
-Returns `{decent: true, message, repository}`, where `message` and `repository` are hard-coded strings for Humans to read. Also returns the status code [`418`](https://en.wikipedia.org/wiki/Hyper_Text_Coffee_Pot_Control_Protocol). Use this endpoint to verify that a given hostname is actually a Decent server
+Returns `{decent: true, message, repository}`, where `message` and `repository` are hard-coded strings for Humans to read. Also returns the status code [`418`](https://en.wikipedia.org/wiki/Hyper_Text_Coffee_Pot_Control_Protocol). Use this endpoint to verify that a given hostname is actually a Decent server.
 
 ### GET `/api/server-settings`
 
@@ -38,9 +40,13 @@ Returns `{success: true, avatarURL}`, where `avatarURL` is a string URL (usually
 
 ### GET `/api/should-use-secure`
 
+- [Authentication](#authentication): never required.
+
 Returns a simple object `{useSecure}`, where `useSecure` is a boolean specifying whether or not to use WebSocket Secure and HTTPS (instead of normal WebSockets and HTTP). Of course, this assumes that HTTPS is properly set up on the host. Whether this returns true or false can be changed via the server command line (see `help` and view information on "set").
 
 ### GET `/api/should-use-authorization`
+
+- [Authentication](#authentication): never required.
 
 Returns an object `{useAuthorization, authorizationMessage}`, where `useAuthorization` is a boolean specifying whether or not to use [authorization](#authorization). If the server does require authorization, `authorizationMessage` (a message [specific to the server](#list-of-server-settings)) is passed.
 


### PR DESCRIPTION
Enables authentication with *any route* via:
* sessionID in post body
* sessionID in query string
* X-Session-ID in request headers

Before, some routes would expect sessionID to be in the post body, some in the query string, etc. This makes them not care. Documentation has been updated to match.

No frontend changes have been made, but it should be trivial to evict all `?sessionID` and `{ sessionID }` declarations in api.js calls. Just using X-Session-ID is definitely much easier.

---

@towerofnix I'd recommend some extra testing for this particular PR than usual. I don't normally work on the backend all that much, and this is an API-wide change. I may have overlooked something.

@TheInitializer this may make weecent's code simpler or something, so you might want to take a look once/if this gets merged.
  
  