### PR TITLE
Scrollforward / Jump to old message

### DIFF
--- a/api.js
+++ b/api.js
@@ -1053,6 +1053,12 @@ module.exports = async function attachAPI(app, {wss, db}) {
         }
       }
 
+      const sort = {date: -1}
+
+      if (afterMessage && !beforeMessage) {
+        sort.date = +1
+      }
+
       // We sort the messages by NEWEST date ({date: -1}), so that we're returned
       // the newest messages, but then we reverse the array, so that the actual
       // data returned from the API is sorted by oldest first. (This is so that
@@ -1061,10 +1067,12 @@ module.exports = async function attachAPI(app, {wss, db}) {
       // TODO: If there is more than 50, show that somehow.
       // TODO: Store 50 as a constant somewhere?
       const cursor = db.messages.cfind(query)
-      cursor.sort({date: -1})
+      cursor.sort(sort)
       cursor.limit(limit ? Math.max(1, Math.min(50, parseInt(limit))) : 50)
       const messages = await cursor.exec()
-      messages.reverse()
+      if (sort.date === -1) {
+        messages.reverse()
+      }
 
       response.status(200).end(JSON.stringify({
         success: true,

--- a/api.js
+++ b/api.js
@@ -1027,6 +1027,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
     ...middleware.loadVarFromParams('channelID'),
     ...middleware.loadVarFromQuery('before', false),
     ...middleware.loadVarFromQuery('after', false),
+    ...middleware.loadVarFromQuery('limit', false),
     ...middleware.getChannelFromID('channelID', '_'), // Just to make sure the channel exists
     ...middleware.runIfVarExists('before',
       middleware.getMessageFromID('before', 'beforeMessage')
@@ -1036,7 +1037,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
     ),
 
     async (request, response) => {
-      const { channelID, beforeMessage, afterMessage } = request[middleware.vars]
+      const { channelID, beforeMessage, afterMessage, limit } = request[middleware.vars]
 
       const query = {channelID}
 
@@ -1061,7 +1062,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
       // TODO: Store 50 as a constant somewhere?
       const cursor = db.messages.cfind(query)
       cursor.sort({date: -1})
-      cursor.limit(50)
+      cursor.limit(limit ? Math.max(1, Math.min(50, parseInt(limit))) : 50)
       const messages = await cursor.exec()
       messages.reverse()
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -125,8 +125,9 @@ Returns `{success: true, channels}`, where channels is an array of [(brief) chan
   * `channelID`: (via URL path) the channel ID to fetch messages from.
   * `before`: (via query; optional) the ID of the message right after the range of messages you want.
   * `after`: (via query; optional) the ID of the message right before the range of messages you want.
+  * `limit`: (via query; optional) the maximum number of messages to fetch (defaults to 50). The actual used limit will be at least 1 and not greater than 50.
 
-Returns `{success: true, messages}`, where messages is an array of the 50 most recent messages sent to the given channel. If `before` is specified, it'll only fetch messages that were sent before that one; and it'll only fetch messages sent after `after`.
+Returns `{success: true, messages}`, where messages is an array of the most recent messages sent to the given channel. If `before` is specified, it'll only fetch messages that were sent before that one; and it'll only fetch messages sent after `after`. If `limit` is specified, it'll only fetch up to that many messages (or up to 50, if not specified).
 
 ### POST `/api/register`
 

--- a/site/src/components/message-group.css
+++ b/site/src/components/message-group.css
@@ -42,6 +42,10 @@
         max-width: 100%;
       }
     }
+
+    &.jumped-to {
+      animation: jumped-message 4s;
+    }
   }
 
   & a:any-link {
@@ -79,5 +83,21 @@
 
     margin: 0 .05em 0 .1em;
     vertical-align: -.4em;
+  }
+}
+
+/* note: this animation name is used in the JavaScript code,
+   so take care if renaming it */
+@keyframes jumped-message {
+  from {
+    background-color: transparent;
+  }
+
+  10% {
+    background-color: rgba(50, 180, 255, 80);
+  }
+
+  to {
+    background-color: transparent;
   }
 }

--- a/site/src/components/messages.js
+++ b/site/src/components/messages.js
@@ -178,7 +178,11 @@ const store = (state, emitter) => {
 
       state.messages.fetching = false
       state.messages.handleScroll = false
-      state.messages.list = [ ...messages, ...(state.messages.list || []) ]
+      state.messages.list = [
+        ...(direction === 'older' ? messages : []),
+        ...(state.messages.list || []),
+        ...(direction === 'newer' ? messages : [])
+      ]
       state.messages.groupsCached = groupMessages(state.messages.list)
 
       // render the new messages!

--- a/site/src/components/messages.js
+++ b/site/src/components/messages.js
@@ -173,10 +173,11 @@ const store = (state, emitter) => {
       : direction === 'older' ? { before: messageID } : { after: messageID }
     )
 
+    state.messages.fetching = false
+
     if (messages.length) {
       const { oldestGroupEl: oldestGroupElBefore } = state.messages
 
-      state.messages.fetching = false
       state.messages.handleScroll = false
       state.messages.list = [
         ...(direction === 'older' ? messages : []),
@@ -208,7 +209,7 @@ const store = (state, emitter) => {
 
         state.messages.handleScroll = true
 
-        emitter.emit('messagse.fetchcomplete')
+        emitter.emit('messages.fetchcomplete')
       }, 25)
     } else {
       // no past messages means we've scrolled to the beginning, so we set
@@ -261,6 +262,7 @@ const store = (state, emitter) => {
     // chunks of the "timeline")
     state.messages.fetching = false
     state.messages.handleScroll = false
+    state.messages.scrolledToBeginning = false
     state.messages.list = [...oldMessages, jumpMessage, ...newMessages]
     state.messages.groupsCached = groupMessages(state.messages.list)
     emitter.emit('render')
@@ -389,6 +391,11 @@ const component = (state, emit) => {
     // to fetch older messages and display 'em
     if (y > 0) {
       emit('messages.fetch', 'older')
+    }
+
+    // if we are nearly scrolled to the bottom, fetch *newer* messages
+    if (evt.target.scrollTop > evt.target.scrollHeight - evt.target.offsetHeight - 25) {
+      emit('messages.fetch', 'newer')
     }
   }
 

--- a/site/src/components/messages.js
+++ b/site/src/components/messages.js
@@ -244,11 +244,11 @@ const store = (state, emitter) => {
     const messagesAPI = `channel/${state.params.channel}/latest-messages`
 
     const { messages: oldMessages } = await api.get(
-      state, `${messagesAPI}?before=${messageID}&limit=${context / 2}`
+      state, messagesAPI, { before: messageID, limit: context / 2 }
     )
 
     const { messages: newMessages } = await api.get(
-      state, `${messagesAPI}?after=${messageID}&limit=${context - oldMessages.length}`
+      state, messagesAPI, { after: messageID, limit: context - oldMessages.length }
     )
 
     const jumpMessage = await api.get(

--- a/site/src/components/messages.js
+++ b/site/src/components/messages.js
@@ -57,7 +57,7 @@ const store = (state, emitter) => {
 
     // true if we've fetched all messages up to the beginning
     // of the channel. used for scrollback
-    fetchedAll: false,
+    scrolledToBeginning: false,
 
     // the oldest message el's y coordinate relative to this component
     // used for scrollback
@@ -123,10 +123,10 @@ const store = (state, emitter) => {
 
   // load more messages from the past - used for scrollback
   // and also initial loading
-  emitter.on('messages.fetch', async () => {
+  emitter.on('messages.fetcholdermessages', async () => {
     // no need to fetch more - we've already fetched every
     // message in this channel!
-    if (state.messages.fetchedAll) return
+    if (state.messages.scrolledToBeginning) return
 
     // if we're currently fetching messages, don't try
     // and fetch even more as we'll run into edge cases
@@ -179,7 +179,7 @@ const store = (state, emitter) => {
       // no past messages means we've scrolled to the beginning, so we set
       // this flag which will stop all this code handling scrollback from
       // happening again (until we move to a different channel)
-      state.messages.fetchedAll = true
+      state.messages.scrolledToBeginning = true
 
       if (!state.messages.list) {
         state.messages.list = []
@@ -195,13 +195,13 @@ const store = (state, emitter) => {
     emitter.emit('messages.reset')
 
     if (state.params.channel) {
-      emitter.emit('messages.fetch')
+      emitter.emit('messages.fetcholdermessages')
     }
   })
 
   emitter.on('login', () => {
     if (state.params.channel) {
-      emitter.emit('messages.fetch')
+      emitter.emit('messages.fetcholdermessages')
     }
   })
 
@@ -291,7 +291,7 @@ const component = (state, emit) => {
     // if y is positive, we've scolled above the top group - so we need
     // to fetch older messages and display 'em
     if (y > 0) {
-      emit('messages.fetch')
+      emit('messages.fetcholdermessages')
     }
   }
 

--- a/site/src/components/messages.js
+++ b/site/src/components/messages.js
@@ -200,7 +200,7 @@ const store = (state, emitter) => {
   })
 
   emitter.on('login', () => {
-    if (state.params.channel) {
+    if (state.serverRequiresAuthorization && state.params.channel) {
       emitter.emit('messages.fetcholdermessages')
     }
   })

--- a/site/src/components/messages.js
+++ b/site/src/components/messages.js
@@ -59,6 +59,10 @@ const store = (state, emitter) => {
     // of the channel. used for scrollback
     scrolledToBeginning: false,
 
+    // same as scrolledToBeginning, but for the end (most recent
+    // messages; used for scrollforward)
+    scrolledToEnd: false,
+
     // the oldest message el's y coordinate relative to this component
     // used for scrollback
     oldestY: 0,
@@ -137,7 +141,8 @@ const store = (state, emitter) => {
 
     // no need to fetch more - we've already fetched every
     // message in this channel!
-    if (state.messages.scrolledToBeginning) return
+    if (direction === 'older' && state.messages.scrolledToBeginning) return
+    if (direction === 'newer' && state.messages.scrolledToEnd) return
 
     // if we're currently fetching messages, don't try
     // and fetch even more as we'll run into edge cases
@@ -215,7 +220,11 @@ const store = (state, emitter) => {
       // no past messages means we've scrolled to the beginning, so we set
       // this flag which will stop all this code handling scrollback from
       // happening again (until we move to a different channel)
-      state.messages.scrolledToBeginning = true
+      if (direction === 'older') {
+        state.messages.scrolledToBeginning = true
+      } else {
+        state.messages.scrolledToEnd = true
+      }
 
       if (!state.messages.list) {
         state.messages.list = []
@@ -263,6 +272,7 @@ const store = (state, emitter) => {
     state.messages.fetching = false
     state.messages.handleScroll = false
     state.messages.scrolledToBeginning = false
+    state.messages.scrolledToEnd = false
     state.messages.list = [...oldMessages, jumpMessage, ...newMessages]
     state.messages.groupsCached = groupMessages(state.messages.list)
     emitter.emit('render')

--- a/site/src/components/messages.js
+++ b/site/src/components/messages.js
@@ -198,7 +198,7 @@ const store = (state, emitter) => {
             // keep relative scroll position after scrollback
             const distance = state.messages.oldestY
 
-            oldestGroupElBefore.scrollIntoView({ behaviour: 'instant' })
+            oldestGroupElBefore.scrollIntoView({ behavior: 'instant' })
             state.messages.el.scrollTop -= distance
           } else {
             // scroll to bottom (initial render)


### PR DESCRIPTION
Fixes #148; fixes #162. Unblocks #17 and #93.

This makes a few (non-breaking) changes to the API (besides fixing some old, broken behavior).

This implements scroll-forwards (loading more recent messages when scrolling down, when newer messages are not loaded) *and* jumping to a message by its ID. There's no exposed UI for that yet, but you can (and should) test it with `choo.emit('messages.jumptomessage', '(messageID)')`.

PS: Firefox (on my machine, anyways) behaves really weirdly, when scrolling backwards *or* forwards? It doesn't actually scroll back to the previously oldest message group after loading the older messages (in the case of loading older messages). Then it immediately loads *more* old messages. That's a cycle, so it keeps loading old messages until all old messages are loaded. (Likewise in the forwards direction.) Does this happen to you, @heyitsmeuralex? I think (*think*, not sure) it might have to do something with smooth-scrolling (grumble). I don't remember if this is a thing or not on Safari/Chrome because I haven't tested decent on other devices in a while.