### PR TITLE
Rename websocket events; fix channel-delete handler of client

### DIFF
--- a/api.js
+++ b/api.js
@@ -1447,7 +1447,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
       const { evt, data } = messageObj
 
-      if (evt === 'pong data') {
+      if (evt === 'pongdata') {
         // Not the built-in pong; this event is used for gathering
         // socket-specific data.
         if (!data) {
@@ -1502,7 +1502,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
     // data (like the session ID) for the socket as soon as possible. Without this
     // we wait for the next ping, which is an unwanted delay (e.g. it would make
     // detecting the user being online be delayed by up to 10 seconds).
-    socket.send(JSON.stringify({evt: 'ping for data'}))
+    socket.send(JSON.stringify({evt: 'pingdata'}))
   })
 
   setInterval(() => {
@@ -1523,7 +1523,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
         // The built-in socket ping method is great for obliterating dead sockets,
         // but we also want to detect data, so we need to send out a normal 'ping'
         // event at the same time, which the client can detect and respond to.
-        socket.send(JSON.stringify({evt: 'ping for data'}))
+        socket.send(JSON.stringify({evt: 'pingdata'}))
       }
     }
   }, 10 * 1000) // Every 10s.

--- a/api.js
+++ b/api.js
@@ -712,7 +712,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
         reactions: {}
       })
 
-      sendToAllSockets('received chat message', {
+      sendToAllSockets('message/new', {
         message: await serialize.message(message)
       })
 
@@ -847,7 +847,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
         returnUpdatedDocs: true
       })
 
-      sendToAllSockets('edited chat message', {message: await serialize.message(newMessage)})
+      sendToAllSockets('message/edit', {message: await serialize.message(newMessage)})
 
       response.status(200).end(JSON.stringify({success: true}))
     }
@@ -875,7 +875,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
       await db.messages.remove({_id: message._id})
 
       // We don't want to send back the message itself, obviously!
-      sendToAllSockets('deleted chat message', {messageID: message._id})
+      sendToAllSockets('message/delete', {messageID: message._id})
 
       response.status(200).end(JSON.stringify({success: true}))
     }
@@ -915,7 +915,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
         pinnedMessageIDs: []
       })
 
-      sendToAllSockets('created new channel', {
+      sendToAllSockets('channel/new', {
         channel: await serialize.channelDetail(channel),
       })
 
@@ -948,7 +948,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
       await db.channels.update({_id: channelID}, {$set: {name}})
 
-      sendToAllSockets('renamed channel', {
+      sendToAllSockets('channel/rename', {
         channelID, newName: name
       })
 
@@ -975,7 +975,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
       ])
 
       // Only send the channel ID, since that's all that's needed.
-      sendToAllSockets('deleted channel', {
+      sendToAllSockets('channel/delete', {
         channelID
       })
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -206,33 +206,33 @@ These are the events which are used to send (and receive) data specific to indiv
 
 This project uses a WebSocket system which is similar to [socket.io](https://socket.io/) (though more simple). Messages sent to and from clients are JSON strings following the format `{evt, data}`, where `evt` is a name representing the meaning of the event, and `data` is an optional property specifying any additional data related to the event.
 
-### To client: `ping for data`
+### To client: `pingdata`
 
 Sent periodically (typically ever 10 seconds) by the server, as well as immediately upon the client socket connecting. Clients should respond with a `pong data` event, as described below.
 
-### From client: `pong data`
+### From client: `pongdata`
 
 Should be sent from clients in response to `ping for data`. Notifies the server of any information related to the particular socket. Passed data should include:
 
 * `sessionID`, if the client is "logged in" or keeping track of a session ID. This is used for keeping track of which users are online.
 
-### From server: `received chat message`
+### From server: `message/new`
 
 Sent to all clients whenever a message is [sent](#post-apisend-message) to any channel in the server. Passed data is in the format `{message}`, where `message` is a [message object](#message-object) representing the new message.
 
-### From server: `edited chat message`
+### From server: `message/edit`
 
 Sent to all clients when any message is [edited](#post-apiedit-message). Passed data is in the format `{message}`, where `message` is a [message object](#message-object) representing the edited message.
 
-### From server: `created new channel`
+### From server: `channel/new`
 
 Sent to all clients when a channel is [created](#post-apicreate-channel). Passed data is in the format `{channel}`, where `channel` is a [(detailed) channel object](#channel-object) representing the new channel.
 
-### From server: `renamed channel`
+### From server: `channel/rename`
 
 Sent to all clients when a channel is [renamed](#post-apirename-channel). Passed data is in the format `{channelID, newName}`.
 
-### From server: `deleted channel`
+### From server: `channel/delete`
 
 Sent to all clients when a channel is [deleted](#post-apidelete-channel). Passed data is in the format `{channelID}`.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,7 +49,7 @@ Returns an object `{useAuthorization, authorizationMessage}`, where `useAuthoriz
   * `channelID`: (via data; string) the ID of the channel to which the message will be sent. The channel has to exist.
   * `sessionID`: (via data; string) the user's session ID. This must be a valid session ID.
 
-Sends a message. Returns an object `{success: true, messageID}` if successful, where `messageID` is the unique ID of the new message, and emits a [`received chat message`](#from-server-received-chat-message) WebSocket event.
+Sends a message. Returns an object `{success: true, messageID}` if successful, where `messageID` is the unique ID of the new message, and emits a [`message/new`](#from-server-messagenew) WebSocket event.
 
 ### GET `/api/message/:messageID`
 
@@ -65,7 +65,7 @@ Returns a [message object](#message-object) corresponding to the given message I
   * `messageID`: (via data; string) the message ID. The message has to exist.
   * `sessionID`: (via data; string) the user's session ID. **The user must own the message.**
 
-Overwrites the text content of an existing message and attaches an "edited" date to it. Returns `{success: true}` if successful, and emits an [`edited chat message`](#from-server-edited-chat-message) WebSocket event.
+Overwrites the text content of an existing message and attaches an "edited" date to it. Returns `{success: true}` if successful, and emits a [`message/edit`](#from-server-messageedit) WebSocket event.
 
 ### POST `/api/pin-message`
 
@@ -85,7 +85,7 @@ This endpoint is unstable. See discussion in [GitHub issue #21](https://github.c
   * `name`: (via data; string) the name of the channel. This must be a [valid name](#valid-names), and there must not already be a channel with the same name.
   * `sessionID`: (via data; string) the user's session ID. **The user must be an admin.**
 
-Creates a channel (which will immediately be able to receive messages). Returns `{success: true, channelID}` if successful, where `channelID` is the unique ID of the channel, and emits a [`created new channel`](#from-server-created-new-channel) WebSocket event.
+Creates a channel (which will immediately be able to receive messages). Returns `{success: true, channelID}` if successful, where `channelID` is the unique ID of the channel, and emits a [`channel/new`](#from-server-channelnew) WebSocket event.
 
 ### GET `/api/channel/:channelID`
 
@@ -102,7 +102,7 @@ Returns `{success: true, channel}` if successful, where `channel` is a [(detaile
   * `channelID`: (via data; string) the unique ID of the channel to be renamed. The channel has to exist.
   * `sessionID`: (via data; string) the session ID of the user. **The user must be an admin.**
 
-Changes the name of a channel. Returns `{success: true}` if successful, and emits a [`renamed channel`](#from-server-renamed-channel) WebSocket event.
+Changes the name of a channel. Returns `{success: true}` if successful, and emits a [`channel/rename`](#from-server-channelrename) WebSocket event.
 
 ### POST `/api/delete-channel`
 
@@ -110,7 +110,7 @@ Changes the name of a channel. Returns `{success: true}` if successful, and emit
   * `channelID`: (via data; string) the unique ID of the channel to be deleted. The channel has to exist.
   * `sessionID`: (via data; string) the session ID of the user. **The user must be an admin.**
 
-Deletes a channel and any messages in it. Returns `{success: true}` if successful, and emits a [`deleted channel`](#from-server-deleted-channel) WebSocket event.
+Deletes a channel and any messages in it. Returns `{success: true}` if successful, and emits a [`channel/delete`](#from-server-channeldelete) WebSocket event.
 
 ### GET `/api/channel-list`
 
@@ -208,11 +208,11 @@ This project uses a WebSocket system which is similar to [socket.io](https://soc
 
 ### To client: `pingdata`
 
-Sent periodically (typically ever 10 seconds) by the server, as well as immediately upon the client socket connecting. Clients should respond with a `pong data` event, as described below.
+Sent periodically (typically ever 10 seconds) by the server, as well as immediately upon the client socket connecting. Clients should respond with a `pongdata` event, as described below.
 
 ### From client: `pongdata`
 
-Should be sent from clients in response to `ping for data`. Notifies the server of any information related to the particular socket. Passed data should include:
+Should be sent from clients in response to `pingdata`. Notifies the server of any information related to the particular socket. Passed data should include:
 
 * `sessionID`, if the client is "logged in" or keeping track of a session ID. This is used for keeping track of which users are online.
 

--- a/site/src/app.js
+++ b/site/src/app.js
@@ -83,6 +83,10 @@ app.use((state, emitter) => {
 
       state.ws = new util.WS(state.params.host, state.secure)
 
+      // wait for the WebSocket to connect, because a bunch of things
+      // basically don't function without it
+      await new Promise(resolve => state.ws.once('open', resolve))
+
       state.ws.on('*', (evt, timestamp, data) => {
         if (evt === 'ping for data') {
           state.ws.send('pong data', {
@@ -90,13 +94,12 @@ app.use((state, emitter) => {
           })
         } else {
           // emit websocket events
-          emitter.emit('ws.' + evt.replace(/ /g, ''), data)
+          emitter.emit('ws.' + evt, data)
+
+          // for debugging:
+          // console.log(`ws[${evt}]:`, data)
         }
       })
-
-      // wait for the WebSocket to connect, because a bunch of things
-      // basically don't function without it
-      await new Promise(resolve => state.ws.once('open', resolve))
 
       emitter.emit('emotes.fetch')
     }

--- a/site/src/app.js
+++ b/site/src/app.js
@@ -88,8 +88,8 @@ app.use((state, emitter) => {
       await new Promise(resolve => state.ws.once('open', resolve))
 
       state.ws.on('*', (evt, timestamp, data) => {
-        if (evt === 'ping for data') {
-          state.ws.send('pong data', {
+        if (evt === 'pingdata') {
+          state.ws.send('pongdata', {
             sessionID: state.session ? state.session.id : null
           })
         } else {

--- a/site/src/components/messages.js
+++ b/site/src/components/messages.js
@@ -326,7 +326,7 @@ const store = (state, emitter) => {
   })
 
   // event: new message
-  emitter.on('ws.receivedchatmessage', ({ message }) => {
+  emitter.on('ws.message/new', ({ message }) => {
     if (message.channelID !== state.params.channel) return
 
     const groups = state.messages.groupsCached
@@ -364,7 +364,7 @@ const store = (state, emitter) => {
   })
 
   // event: edit message
-  emitter.on('ws.editedchatmessage', ({ message: msg }) => {
+  emitter.on('ws.message/edit', ({ message: msg }) => {
     if (msg.channelID !== state.params.channel) return
 
     // optimization :tada:

--- a/site/src/components/sidebar.js
+++ b/site/src/components/sidebar.js
@@ -212,7 +212,6 @@ const store = (state, emitter) => {
 
   // event: channel added
   emitter.on('ws.channel/new', ({ channel }) => {
-    console.log('well, hey', channel)
     state.sidebar.channels.push(channel)
     emitter.emit('render')
   })

--- a/site/src/components/sidebar.js
+++ b/site/src/components/sidebar.js
@@ -211,13 +211,14 @@ const store = (state, emitter) => {
   })
 
   // event: channel added
-  emitter.on('ws.creatednewchannel', ({ channel }) => {
+  emitter.on('ws.channel/new', ({ channel }) => {
+    console.log('well, hey', channel)
     state.sidebar.channels.push(channel)
     emitter.emit('render')
   })
 
   // event: channel renamed
-  emitter.on('ws.renamedchannel', ({ channelID, newName }) => {
+  emitter.on('ws.channel/rename', ({ channelID, newName }) => {
     const channel = state.sidebar.channels.find(c => channelID === c.id)
     channel.name = newName
 
@@ -225,9 +226,15 @@ const store = (state, emitter) => {
   })
 
   // event: channel deleted
-  emitter.on('ws.deletedchannel', ({ channelID }) => {
-    state.sidebar.channels = state.sidebar.channels.filter(c => channelID !== id)
-    emitter.emit('render')
+  emitter.on('ws.channel/delete', ({ channelID }) => {
+    state.sidebar.channels = state.sidebar.channels.filter(c => channelID !== c.id)
+
+    if (state.params.channel === channelID) {
+      // changing the state will re-render, so no need to also emit render
+      emitter.emit('pushState', `/servers/${state.params.host}`)
+    } else {
+      emitter.emit('render')
+    }
   })
 
   /** session related ***/


### PR DESCRIPTION
Renames a bunch of WebSocket events:

* `ping for data` -> `pingdata`
* `pong data` -> `pongdata`
* `received chat message` -> `message/new`
* `edited chat message` -> `message/edit`
* `created new channel` -> `channel/new`
* `renamed channel` -> `channel/rename`
* `deleted channel` -> `channel/delete`

Updates the client to deal with these changes, as well.

Also fixes the code which handled "deleted channel"; this used to error, but now actually removes the channel from the channel list (with no error).