### PR TITLE
Fix missing padding at the bottom of .page elements

### DIFF
--- a/site/src/app.css
+++ b/site/src/app.css
@@ -78,6 +78,14 @@ body {
       font-size: 24px;
     }
   }
+
+  /* since bottom padding doesn't actually do anything, we need to add a
+     margin onto the bottom element
+     (this only works as long as the bottom element in the page is a block-
+     level element, but hopefully that will always be the case) */
+  & > :last-child {
+    margin-bottom: 36px;
+  }
 }
 
 .styled-input {


### PR DESCRIPTION
This adds a margin to the bottom child element of `.page`s, so that you can scroll that distance ahead. This only really has an effect when the browser window is fairly short; before, elements like the table in the account settings page would appear right at the bottom of the screen (so the bottom of the table touched the bottom of the page).