### PR TITLE
Implement user online/offline internals much better

### DIFF
--- a/api.js
+++ b/api.js
@@ -1447,7 +1447,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
       const { evt, data } = messageObj
 
-      if (evt === 'pong data') {
+      if (evt === 'pongdata') {
         // Not the built-in pong; this event is used for gathering
         // socket-specific data.
         if (!data) {
@@ -1502,7 +1502,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
     // data (like the session ID) for the socket as soon as possible. Without this
     // we wait for the next ping, which is an unwanted delay (e.g. it would make
     // detecting the user being online be delayed by up to 10 seconds).
-    socket.send(JSON.stringify({evt: 'ping for data'}))
+    socket.send(JSON.stringify({evt: 'pingdata'}))
   })
 
   setInterval(() => {
@@ -1523,7 +1523,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
         // The built-in socket ping method is great for obliterating dead sockets,
         // but we also want to detect data, so we need to send out a normal 'ping'
         // event at the same time, which the client can detect and respond to.
-        socket.send(JSON.stringify({evt: 'ping for data'}))
+        socket.send(JSON.stringify({evt: 'pingdata'}))
       }
     }
   }, 10 * 1000) // Every 10s.

--- a/api.js
+++ b/api.js
@@ -712,7 +712,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
         reactions: {}
       })
 
-      sendToAllSockets('received chat message', {
+      sendToAllSockets('message/new', {
         message: await serialize.message(message)
       })
 
@@ -847,7 +847,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
         returnUpdatedDocs: true
       })
 
-      sendToAllSockets('edited chat message', {message: await serialize.message(newMessage)})
+      sendToAllSockets('message/edit', {message: await serialize.message(newMessage)})
 
       response.status(200).end(JSON.stringify({success: true}))
     }
@@ -875,7 +875,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
       await db.messages.remove({_id: message._id})
 
       // We don't want to send back the message itself, obviously!
-      sendToAllSockets('deleted chat message', {messageID: message._id})
+      sendToAllSockets('message/delete', {messageID: message._id})
 
       response.status(200).end(JSON.stringify({success: true}))
     }
@@ -915,7 +915,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
         pinnedMessageIDs: []
       })
 
-      sendToAllSockets('created new channel', {
+      sendToAllSockets('channel/new', {
         channel: await serialize.channelDetail(channel),
       })
 
@@ -948,7 +948,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
       await db.channels.update({_id: channelID}, {$set: {name}})
 
-      sendToAllSockets('renamed channel', {
+      sendToAllSockets('channel/rename', {
         channelID, newName: name
       })
 
@@ -975,7 +975,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
       ])
 
       // Only send the channel ID, since that's all that's needed.
-      sendToAllSockets('deleted channel', {
+      sendToAllSockets('channel/delete', {
         channelID
       })
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -206,33 +206,33 @@ These are the events which are used to send (and receive) data specific to indiv
 
 This project uses a WebSocket system which is similar to [socket.io](https://socket.io/) (though more simple). Messages sent to and from clients are JSON strings following the format `{evt, data}`, where `evt` is a name representing the meaning of the event, and `data` is an optional property specifying any additional data related to the event.
 
-### To client: `ping for data`
+### To client: `pingdata`
 
 Sent periodically (typically ever 10 seconds) by the server, as well as immediately upon the client socket connecting. Clients should respond with a `pong data` event, as described below.
 
-### From client: `pong data`
+### From client: `pongdata`
 
 Should be sent from clients in response to `ping for data`. Notifies the server of any information related to the particular socket. Passed data should include:
 
 * `sessionID`, if the client is "logged in" or keeping track of a session ID. This is used for keeping track of which users are online.
 
-### From server: `received chat message`
+### From server: `message/new`
 
 Sent to all clients whenever a message is [sent](#post-apisend-message) to any channel in the server. Passed data is in the format `{message}`, where `message` is a [message object](#message-object) representing the new message.
 
-### From server: `edited chat message`
+### From server: `message/edit`
 
 Sent to all clients when any message is [edited](#post-apiedit-message). Passed data is in the format `{message}`, where `message` is a [message object](#message-object) representing the edited message.
 
-### From server: `created new channel`
+### From server: `channel/new`
 
 Sent to all clients when a channel is [created](#post-apicreate-channel). Passed data is in the format `{channel}`, where `channel` is a [(detailed) channel object](#channel-object) representing the new channel.
 
-### From server: `renamed channel`
+### From server: `channel/rename`
 
 Sent to all clients when a channel is [renamed](#post-apirename-channel). Passed data is in the format `{channelID, newName}`.
 
-### From server: `deleted channel`
+### From server: `channel/delete`
 
 Sent to all clients when a channel is [deleted](#post-apidelete-channel). Passed data is in the format `{channelID}`.
 

--- a/site/src/app.js
+++ b/site/src/app.js
@@ -144,7 +144,7 @@ app.use((state, emitter) => {
           emitter.emit('ws.' + evt, data)
 
           // for debugging:
-          console.log(`ws[${evt}]:`, data)
+          // console.log(`ws[${evt}]:`, data)
         }
       })
 

--- a/site/src/app.js
+++ b/site/src/app.js
@@ -45,6 +45,53 @@ app.use((state, emitter) => {
     }
   })
 
+  // This whole mess of the _session Proxy and the session property are used to
+  // handle the session object being changed; whenever the session ID changes
+  // (be it because we set the changed session.id, completely overwrote session,
+  // deleted session or session.id, etc), we want to send the new session ID to
+  // the server (so that it knows that the user of the old session ID went
+  // offline and the user of the new session ID came online).
+
+  state._session = new Proxy({}, {
+    set: function(target, key, value) {
+      if (key === 'id') {
+        if (target.id !== value) {
+          state.ws.send('pongdata', { sessionID: value })
+        }
+      }
+
+      return Reflect.set(target, key, value)
+    },
+
+    deleteProperty: function(target, key) {
+      if (key === 'id') {
+        state.ws.send('pongdata', { sessionID: null })
+      }
+
+      return Reflect.deleteProperty(target, key)
+    }
+  })
+
+  Object.defineProperty(state, 'session', {
+    get: function() {
+      return state._session
+    },
+
+    set: function(newSession) {
+      // Delete keys which aren't found on the session.
+      for (const key of Object.keys(state._session)) {
+        if (newSession === null || Object.keys(newSession).includes(key) === false) {
+          delete state._session[key]
+        }
+      }
+
+      // Then assign the new values.
+      // We assign to state.session here because state.session will
+      // automatically deal with setting properties nicely.
+      Object.assign(state.session, newSession)
+    }
+  })
+
   // publish state for debugging/experimenting as well
   window.state = state
 
@@ -90,14 +137,14 @@ app.use((state, emitter) => {
       state.ws.on('*', (evt, timestamp, data) => {
         if (evt === 'pingdata') {
           state.ws.send('pongdata', {
-            sessionID: state.session ? state.session.id : null
+            sessionID: state.session.id
           })
         } else {
           // emit websocket events
           emitter.emit('ws.' + evt, data)
 
           // for debugging:
-          // console.log(`ws[${evt}]:`, data)
+          console.log(`ws[${evt}]:`, data)
         }
       })
 
@@ -169,7 +216,7 @@ for (const [ name, s ] of Object.entries(srvSettings)) {
 
   // server settings (admins only) page
   app.route('/servers/:host/settings/:setting', (state, emit) => {
-    if (!state.session || state.session.user.permissionLevel !== 'admin' || !srvSettings[state.params.setting]) {
+    if (state.session.id === null || state.session.user.permissionLevel !== 'admin' || !srvSettings[state.params.setting]) {
       return notFound(state, emit)
     }
 

--- a/site/src/app.js
+++ b/site/src/app.js
@@ -83,6 +83,10 @@ app.use((state, emitter) => {
 
       state.ws = new util.WS(state.params.host, state.secure)
 
+      // wait for the WebSocket to connect, because a bunch of things
+      // basically don't function without it
+      await new Promise(resolve => state.ws.once('open', resolve))
+
       state.ws.on('*', (evt, timestamp, data) => {
         if (evt === 'ping for data') {
           state.ws.send('pong data', {
@@ -90,13 +94,12 @@ app.use((state, emitter) => {
           })
         } else {
           // emit websocket events
-          emitter.emit('ws.' + evt.replace(/ /g, ''), data)
+          emitter.emit('ws.' + evt, data)
+
+          // for debugging:
+          // console.log(`ws[${evt}]:`, data)
         }
       })
-
-      // wait for the WebSocket to connect, because a bunch of things
-      // basically don't function without it
-      await new Promise(resolve => state.ws.once('open', resolve))
 
       emitter.emit('emotes.fetch')
     }

--- a/site/src/app.js
+++ b/site/src/app.js
@@ -88,8 +88,8 @@ app.use((state, emitter) => {
       await new Promise(resolve => state.ws.once('open', resolve))
 
       state.ws.on('*', (evt, timestamp, data) => {
-        if (evt === 'ping for data') {
-          state.ws.send('pong data', {
+        if (evt === 'pingdata') {
+          state.ws.send('pongdata', {
             sessionID: state.session ? state.session.id : null
           })
         } else {

--- a/site/src/components/message-editor.js
+++ b/site/src/components/message-editor.js
@@ -77,7 +77,7 @@ const component = (state, emit) => {
     }
   })
 
-  if (state.session) {
+  if (state.session.id) {
     const editor = html`<div class=${prefix}>
       ${textarea}
       <button onclick=${send}>Send</button>

--- a/site/src/components/messages.js
+++ b/site/src/components/messages.js
@@ -326,7 +326,7 @@ const store = (state, emitter) => {
   })
 
   // event: new message
-  emitter.on('ws.receivedchatmessage', ({ message }) => {
+  emitter.on('ws.message/new', ({ message }) => {
     if (message.channelID !== state.params.channel) return
 
     const groups = state.messages.groupsCached
@@ -364,7 +364,7 @@ const store = (state, emitter) => {
   })
 
   // event: edit message
-  emitter.on('ws.editedchatmessage', ({ message: msg }) => {
+  emitter.on('ws.message/edit', ({ message: msg }) => {
     if (msg.channelID !== state.params.channel) return
 
     // optimization :tada:

--- a/site/src/components/sidebar.js
+++ b/site/src/components/sidebar.js
@@ -212,7 +212,6 @@ const store = (state, emitter) => {
 
   // event: channel added
   emitter.on('ws.channel/new', ({ channel }) => {
-    console.log('well, hey', channel)
     state.sidebar.channels.push(channel)
     emitter.emit('render')
   })

--- a/site/src/components/sidebar.js
+++ b/site/src/components/sidebar.js
@@ -211,13 +211,14 @@ const store = (state, emitter) => {
   })
 
   // event: channel added
-  emitter.on('ws.creatednewchannel', ({ channel }) => {
+  emitter.on('ws.channel/new', ({ channel }) => {
+    console.log('well, hey', channel)
     state.sidebar.channels.push(channel)
     emitter.emit('render')
   })
 
   // event: channel renamed
-  emitter.on('ws.renamedchannel', ({ channelID, newName }) => {
+  emitter.on('ws.channel/rename', ({ channelID, newName }) => {
     const channel = state.sidebar.channels.find(c => channelID === c.id)
     channel.name = newName
 
@@ -225,9 +226,15 @@ const store = (state, emitter) => {
   })
 
   // event: channel deleted
-  emitter.on('ws.deletedchannel', ({ channelID }) => {
-    state.sidebar.channels = state.sidebar.channels.filter(c => channelID !== id)
-    emitter.emit('render')
+  emitter.on('ws.channel/delete', ({ channelID }) => {
+    state.sidebar.channels = state.sidebar.channels.filter(c => channelID !== c.id)
+
+    if (state.params.channel === channelID) {
+      // changing the state will re-render, so no need to also emit render
+      emitter.emit('pushState', `/servers/${state.params.host}`)
+    } else {
+      emitter.emit('render')
+    }
   })
 
   /** session related ***/

--- a/site/src/components/sidebar.js
+++ b/site/src/components/sidebar.js
@@ -152,7 +152,7 @@ const store = (state, emitter) => {
   // fetch the channel list from the server
   emitter.on('sidebar.fetchchannels', async () => {
     if (state.sessionAuthorized) {
-      const data = state.session ? { sessionID: state.session.id } : {}
+      const data = state.session.id ? { sessionID: state.session.id } : {}
       const { channels } = await api.get(state, 'channel-list', data)
       state.sidebar.channels = channels
     } else {
@@ -331,7 +331,7 @@ const store = (state, emitter) => {
 
   // logout
   emitter.on('sidebar.logout', async () => {
-    if (state.session) {
+    if (state.session.id) {
       await api.post(state, 'delete-sessions', {
         sessionIDs: [state.session.id]
       })
@@ -387,7 +387,7 @@ const component = (state, emit) => {
       ` : html`<span></span>`}
 
       ${state.params.host ? (() => {
-        if (state.session) {
+        if (state.session.user) {
           return html`<div class='session'>
             <div class='text'>
               Logged in as
@@ -414,7 +414,7 @@ const component = (state, emit) => {
         (!state.serverRequiresAuthorization || state.sessionAuthorized) ? html`<section>
       <div class='subtitle'>
         <h4>Channels</h4>
-        ${state.session && state.session.user.permissionLevel === 'admin'
+        ${state.session.user && state.session.user.permissionLevel === 'admin'
           ? html`<button onclick=${() => emit('sidebar.createchannel')}>+ Create</button>`
           : html`<span></span>`}
       </div>
@@ -442,7 +442,7 @@ const component = (state, emit) => {
       </div>
     </section>` : html`<span></span>`}
 
-    ${state.session && state.session.user.permissionLevel === 'admin' ? html`<section>
+    ${state.session.user && state.session.user.permissionLevel === 'admin' ? html`<section>
       <div class='subtitle'>
         <h4>Server settings</h4>
       </div>

--- a/site/src/components/srv-settings/authorized-users.js
+++ b/site/src/components/srv-settings/authorized-users.js
@@ -26,7 +26,7 @@ const store = (state, emitter) => {
       state.serverRequiresAuthorization === false ||
 
       // and it definitely won't work if the user is logged out
-      state.session === null
+      state.session.id === null
     ) return
 
     state.authorizedUsers.fetching = true

--- a/site/src/util/api.js
+++ b/site/src/util/api.js
@@ -34,7 +34,7 @@ module.exports = {
   get(state, path, query = {}) {
     // Set the session ID if it's set on the state, but only if not already
     // set by the passed query.
-    if (state.session && !query.sessionID) {
+    if (state.session.id && !query.sessionID) {
       query.sessionID = state.session.id
     }
 
@@ -51,7 +51,7 @@ module.exports = {
   post(state, path, data = {}) {
     // As with get, set the session ID if it's on the state and issing
     // from the data object.
-    if (state.session && !data.sessionID) {
+    if (state.session.id && !data.sessionID) {
       data.sessionID = state.session.id
     }
 


### PR DESCRIPTION
This is blocked by #169 (since it includes commits from that).

This shouldn't be merged until the API docs are updated to include `user/onilne` and `user/offline`, but the PR can be reviewed now.

Copying the text from the commit:

---

This commit comes in three parts:

* Backend changes. When `pongdata` sees that a socket's session ID has changed, it announces that the previous user went offline and that the current user went online. (Note that `socketData` now keeps track of `userID`.)

* Client session object proxy. This is so that `pongdata` is sent whenever the `session` object's `id` attribute is changed (in any way).

* Client compatibility changes. Since the session object is now a proxy, it is always of the type 'object', so we need to be careful when checking if it exists (you can't do `state.session ? 'logged in' : 'logged out'` anymore).

This isn't actually exposed to the user of the client yet; this commit simply implements the internals. If you view the browser console, you'll see `ws.user/offline` and `ws.user/online` events ("no handler for ws.user/online", etc).