### PR TITLE
Use 'usr/bin/env node' for CLI shebang line

### DIFF
--- a/packages/cli/bin/decent.js
+++ b/packages/cli/bin/decent.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 const server = require('@decent/server')
 const client = require('@decent/client')


### PR DESCRIPTION
`/usr/bin/env` is always available, whereas `/usr/bin/node` may not be (e.g. if `nvm` is used). This PR fixes that.

(Labeling this because the CLI not working on systems that don't have `/usr/bin/node` is a bug!)