### PR TITLE
Fix "data" arg of ws.* events being the event timestamp

### DIFF
--- a/packages/client/src/app.js
+++ b/packages/client/src/app.js
@@ -134,7 +134,7 @@ app.use((state, emitter) => {
       // basically don't function without it
       await new Promise(resolve => state.ws.once('open', resolve))
 
-      state.ws.on('*', (evt, timestamp, data) => {
+      state.ws.on('*', (evt, data, timestamp) => {
         if (evt === 'pingdata') {
           state.ws.send('pongdata', {
             sessionID: state.session.id


### PR DESCRIPTION
Obviously `data` should be the data (e.g. `{ message: {} }`), but instead it was the timestamp at which the event was gotten. This fixes that. (This is a very very important fix because without it, the client doesn't react to *any* WS events correctly.)