### PR TITLE
Respond full user list if authorization is disabled

### DIFF
--- a/packages/server/api.js
+++ b/packages/server/api.js
@@ -341,7 +341,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
         }
       }).concat(runIfNot.map(callback => async (request, response, next) => {
         if (!await conditionFn()) {
-          callback(request, rseponse, next)
+          callback(request, response, next)
         } else {
           next()
         }
@@ -1225,7 +1225,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
   ])
 
   app.get('/api/user-list', [
-    ...middleware.runIfCondition(() => shouldUseAuthorization, [
+    ...middleware.runIfCondition(() => shouldUseAuthorization(), [
       async (request, response) => {
         const { sessionUser } = request[middleware.vars]
         const isAdmin = sessionUser && sessionUser.permissionLevel === 'admin'


### PR DESCRIPTION
Fixes #191.

It turns out we weren't checking for authorization properly, so the "else" block wasn't being activated. And there was a typo in `runIfCondition` preventing "else" blocks from working, anyways; that's fixed as well.

@heyitsmeuralex I marked this semver: patch, but I'm not actually experienced with semantic versioning; is that right?