### PR TITLE
Fix client

### DIFF
--- a/packages/cli/bin/decent.js
+++ b/packages/cli/bin/decent.js
@@ -17,7 +17,7 @@ server(port, dbDir).then(async ({ settings, app, db }) => {
   }
 
   app.use(express.static(client)) // index.html, dist/, img/
-  app.get('*', (req, res) => res.sendFile(client + '/index.html'))
+  app.get(/^(?!\/api)/, (req, res) => res.sendFile(client + '/index.html'))
 
   const rl = readline.createInterface({
     input: process.stdin,

--- a/packages/client/src/app.js
+++ b/packages/client/src/app.js
@@ -114,19 +114,14 @@ app.use((state, emitter) => {
         break handleHostChange
       }
 
-      const { useAuthorization, authorizationMessage } = (
-        await api.get(state, 'should-use-authorization')
-      )
+      const { useSecure, useAuthorization, authorizationMessage } = await api.get(state, 'properties')
 
       state.serverRequiresAuthorization = useAuthorization
+      state.secure = useSecure
 
       if (useAuthorization) {
         state.authorizationMessage = authorizationMessage
       }
-
-      state.secure = (
-        await api.get(state, 'should-use-secure')
-      ).useSecure
 
       state.ws = new util.WS(state.params.host, state.secure)
 

--- a/packages/client/src/components/account-settings.js
+++ b/packages/client/src/components/account-settings.js
@@ -75,10 +75,7 @@ const component = (state, emit) => {
       statusEl.innerText = 'Saving...'
 
       try {
-        const { avatarURL } = await api.post(state, 'account-settings', {
-          email,
-          sessionID: state.session.id,
-        })
+        const { avatarURL } = await api.post(state, 'account-settings', {email})
 
         Object.assign(state.session.user, {
           email, avatarURL,

--- a/packages/client/src/components/message-editor.js
+++ b/packages/client/src/components/message-editor.js
@@ -14,10 +14,8 @@ const component = (state, emit) => {
     if (text.length === 0) return
     textarea.value = ''
 
-    await api.post(state, 'send-message', {
-      text,
-      channelID: state.params.channel,
-      sessionID: state.session.id,
+    await api.post(state, 'messages', {
+      text, channelID: state.params.channel,
     })
   }
 
@@ -57,15 +55,15 @@ const component = (state, emit) => {
     progressBar.classList.add('moving')
 
     try {
+      console.log(state.session.id)
       const { path } = await api.postRaw(state, 'upload-image?sessionID=' + state.session.id, formData)
 
       progressBar.style.width = '90%'
 
       // send a message with the image in it
-      await api.post(state, 'send-message', {
+      await api.post(state, 'messages', {
         text: `![](${state.secure ? 'https' : 'http'}://${state.params.host}${path})`,
-        channelID: state.params.channel,
-        sessionID: state.session.id,
+        channelID: state.params.channel
       })
 
       progressBar.style.width = '100%'

--- a/packages/client/src/components/message-editor.js
+++ b/packages/client/src/components/message-editor.js
@@ -20,10 +20,10 @@ const component = (state, emit) => {
   }
 
   textarea.addEventListener('keydown', evt => {
-    const key = evt.which
+    const key = (evt.which || evt.keyCode)
 
-    // enter
     if (key === 13) {
+      // enter/return
       if (evt.shiftKey) {
         // if shift is down, enter a newline
         // this is default behaviour
@@ -31,6 +31,18 @@ const component = (state, emit) => {
         // if shift is not down, send the message
         evt.preventDefault()
         send()
+      }
+    } else if (key === 38) {
+      // up arrow
+      if (evt.altKey) {
+        evt.preventDefault()
+        emit('sidebar.upchannel')
+      }
+    } else if (key === 40) {
+      // down arrow
+      if (evt.altKey) {
+        evt.preventDefault()
+        emit('sidebar.downchannel')
       }
     }
   })
@@ -88,6 +100,12 @@ const component = (state, emit) => {
     editor.isSameNode = a => {
       return a.className === editor.className
     }
+
+    // Hack!!! - Select the textarea *soon*. We assume that the component is
+    // rendered and on the page by 25ms from now.
+    setInterval(() => {
+      textarea.focus()
+    }, 25)
 
     return editor
   } else {

--- a/packages/client/src/components/messages.js
+++ b/packages/client/src/components/messages.js
@@ -172,7 +172,7 @@ const store = (state, emitter) => {
 
     // fetch messages before the oldest message we have. if we don't have an oldest message (i.e. list.length == 0)
     // then we will just fetch the latest messages via no `before` parameter
-    const { messages } = await api.get(state, `channel/${state.params.channel}/latest-messages`,
+    const { messages } = await api.get(state, `channels/${state.params.channel}/messages`,
       messageID === null
       ? {}
       : direction === 'older' ? { before: messageID } : { after: messageID }
@@ -251,7 +251,7 @@ const store = (state, emitter) => {
     // message that is jumped to)
     const context = 50
 
-    const messagesAPI = `channel/${state.params.channel}/latest-messages`
+    const messagesAPI = `channels/${state.params.channel}/messages`
 
     const { messages: oldMessages } = await api.get(
       state, messagesAPI, { before: messageID, limit: context / 2 }

--- a/packages/client/src/components/sidebar.js
+++ b/packages/client/src/components/sidebar.js
@@ -202,6 +202,28 @@ const store = (state, emitter) => {
     emitter.emit('pushState', `/servers/${state.params.host}/channels/${id}`)
   })
 
+
+  // move up/down the channel list
+  emitter.on('sidebar.upchannel', () => {
+    let index = state.sidebar.channels.findIndex(c => c.id === state.params.channel)
+    if (index === 0) {
+      index = state.sidebar.channels.length - 1
+    } else {
+      index--
+    }
+    emitter.emit('sidebar.switchchannel', state.sidebar.channels[index].id)
+  })
+
+  emitter.on('sidebar.downchannel', () => {
+    let index = state.sidebar.channels.findIndex(c => c.id === state.params.channel)
+    if (index === state.sidebar.channels.length - 1) {
+      index = 0
+    } else {
+      index++
+    }
+    emitter.emit('sidebar.switchchannel', state.sidebar.channels[index].id)
+  })
+
   // event: channel added
   emitter.on('ws.channel/new', ({ channel }) => {
     state.sidebar.channels.push(channel)

--- a/packages/client/src/components/sidebar.js
+++ b/packages/client/src/components/sidebar.js
@@ -199,9 +199,11 @@ const store = (state, emitter) => {
 
   // switch to a channel
   emitter.on('sidebar.switchchannel', id => {
-    emitter.emit('pushState', `/servers/${state.params.host}/channels/${id}`)
+    // Don't switch to the channel if we're already viewing it!
+    if (!(state.route === '/servers/:host/channels/:channel' && state.params.channel === id)) {
+      emitter.emit('pushState', `/servers/${state.params.host}/channels/${id}`)
+    }
   })
-
 
   // move up/down the channel list
   emitter.on('sidebar.upchannel', () => {

--- a/packages/client/src/components/sidebar.js
+++ b/packages/client/src/components/sidebar.js
@@ -55,10 +55,10 @@ const store = (state, emitter) => {
 
       // check host is a decent server
       try {
-        const { decent } = await fetch(`//${host}/api/`)
+        const { decentVersion } = await fetch(`//${host}/api/`)
           .then(res => res.json())
 
-        if (!decent) {
+        if (!decentVersion) {
           throw new Error('not a decent server')
         }
 

--- a/packages/client/src/components/sidebar.js
+++ b/packages/client/src/components/sidebar.js
@@ -152,8 +152,7 @@ const store = (state, emitter) => {
   // fetch the channel list from the server
   emitter.on('sidebar.fetchchannels', async () => {
     if (state.sessionAuthorized) {
-      const data = state.session.id ? { sessionID: state.session.id } : {}
-      const { channels } = await api.get(state, 'channel-list', data)
+      const { channels } = await api.get(state, 'channels')
       state.sidebar.channels = channels
     } else {
       state.sidebar.channels = []
@@ -184,9 +183,8 @@ const store = (state, emitter) => {
       modal.disable()
 
       try {
-        await api.post(state, 'create-channel', {
+        await api.post(state, 'channels', {
           name: channelName.trim(),
-          sessionID: state.session.id,
         })
 
         modal.close()
@@ -256,9 +254,7 @@ const store = (state, emitter) => {
       modal.disable()
 
       try {
-        await api.post(state, 'register', { username, password })
-
-        // close the modal
+        await api.post(state, 'users', { username, password })
         modal.close()
       } catch (error) {
         if (error.code === 'INVALID_NAME') {
@@ -268,7 +264,10 @@ const store = (state, emitter) => {
         }
 
         modal.disable(false) // enable
+        return
       }
+
+      await login(username, password)
     })
   })
 
@@ -294,12 +293,7 @@ const store = (state, emitter) => {
 
     modal.on('submit', async ({ username, password }) => {
       try {
-        const { sessionID } = await api.post(state, 'login', { username, password })
-        await loadSessionID(sessionID)
-        storage.set('sessionID@' + state.params.host, sessionID)
-        emitter.emit('render')
-
-        // close the modal
+        await login(username, password)
         modal.close()
       } catch (error) {
         if (error.code === 'NOT_FOUND') {
@@ -311,19 +305,41 @@ const store = (state, emitter) => {
     })
   })
 
+  async function login(username, password) {
+    const { sessionID } = await api.post(state, 'sessions', { username, password })
+    await loadSessionID(sessionID)
+    storage.set('sessionID@' + state.params.host, sessionID)
+    emitter.emit('render')
+  }
+
   // logout
   emitter.on('sidebar.logout', async () => {
     if (state.session.id) {
-      await api.post(state, 'delete-sessions', {
-        sessionIDs: [state.session.id]
-      })
+      try {
+        await api.delete(state, 'sessions/' + state.session.id)
+      } catch (error) {
+        // It's okay to log out from a session which does not exist (e.g.
+        // if sidebar.logout is emitted immediately after deleting the current
+        // session from some other code).
+        if (error.code !== 'NOT_FOUND') {
+          throw error
+        }
+      }
     }
 
     state.session = null
     state.sessionAuthorized = null
     storage.set('sessionID@' + state.params.host, null)
     emitter.emit('logout')
-    emitter.emit('render')
+
+    // Logging out from the account settings page should quit back to the
+    // server homepage, since it doesn't make sense to try to change account
+    // settings while not logged in.
+    if (state.route === '/servers/:host/account') {
+      emitter.emit('pushState', `/servers/${state.params.host}`)
+    } else {
+      emitter.emit('render')
+    }
   })
 
   // fetch channels after logging in/out
@@ -331,12 +347,10 @@ const store = (state, emitter) => {
   emitter.on('logout', () => emitter.emit('sidebar.fetchchannels'))
 
   async function loadSessionID(sessionID) {
-    const { session } = await api.get(state, 'session/' + sessionID, {sessionID})
-    if (session.user) {
-      state.session = { id: sessionID, user: session.user }
-
-      state.sessionAuthorized = session.user.authorized
-
+    const { user } = await api.get(state, 'sessions/' + sessionID)
+    if (user) {
+      state.session = { id: sessionID, user }
+      state.sessionAuthorized = user.authorized
       emitter.emit('login')
     } else {
       state.session = null

--- a/packages/client/src/components/srv-settings/authorized-users.js
+++ b/packages/client/src/components/srv-settings/authorized-users.js
@@ -31,20 +31,12 @@ const store = (state, emitter) => {
 
     state.authorizedUsers.fetching = true
 
-    {
-      // technically passing sessionID here is redundant, since api.get
-      // will automatically add it, But Whatever
-      const result = await api.get(state, 'user-list', {sessionID: api.sessionID})
+    const { users, unauthorizedUsers } = await api.get(state, 'user-list')
+    state.authorizedUsers.authorizedList = users
+    state.authorizedUsers.unauthorizedList = unauthorizedUsers
 
-      state.authorizedUsers.authorizedList = result.users
-      state.authorizedUsers.unauthorizedList = result.unauthorizedUsers
-    }
-
-    {
-      const { authorizationMessage } = await api.get(state, 'settings')
-
-      state.authorizedUsers.authorizationMessage = authorizationMessage
-    }
+    const { authorizationMessage } = await api.get(state, 'settings')
+    state.authorizedUsers.authorizationMessage = authorizationMessage
 
     state.authorizedUsers.fetching = false
     state.authorizedUsers.fetched = true
@@ -62,17 +54,13 @@ const store = (state, emitter) => {
   })
 
   emitter.on('authorizedUsers.authorizeUser', async userID => {
-    await api.post(state, 'authorize-user', {
-      userID, sessionID: state.session.id
-    })
+    await api.post(state, 'authorize-user', {userID})
 
     emitter.emit('authorizedUsers.fetch')
   })
 
   emitter.on('authorizedUsers.deauthorizeUser', async userID => {
-    await api.post(state, 'deauthorize-user', {
-      userID, sessionID: state.session.id
-    })
+    await api.post(state, 'deauthorize-user', {userID})
 
     emitter.emit('authorizedUsers.fetch')
   })

--- a/packages/client/src/components/srv-settings/authorized-users.js
+++ b/packages/client/src/components/srv-settings/authorized-users.js
@@ -41,9 +41,9 @@ const store = (state, emitter) => {
     }
 
     {
-      const result = await api.get(state, 'server-settings')
+      const { authorizationMessage } = await api.get(state, 'settings')
 
-      state.authorizedUsers.authorizationMessage = result.authorizationMessage
+      state.authorizedUsers.authorizationMessage = authorizationMessage
     }
 
     state.authorizedUsers.fetching = false
@@ -54,11 +54,7 @@ const store = (state, emitter) => {
   emitter.on('authorizedUsers.saveMessage', async () => {
     const authorizationMessage = document.getElementById(`${prefix}message`).value
 
-    await api.post(state, 'server-settings', {
-      patch: {
-        authorizationMessage
-      }
-    })
+    await api.patch(state, 'settings', {authorizationMessage})
 
     state.authorizedUsers.authMessageSaved = true
 

--- a/packages/client/src/components/srv-settings/emotes.js
+++ b/packages/client/src/components/srv-settings/emotes.js
@@ -17,7 +17,7 @@ const store = (state, emitter) => {
 
     state.emotes.fetching = true
 
-    const { settings: { emotes } } = await api.get(state, 'server-settings')
+    const { emotes } = await api.get(state, 'emotes')
 
     state.emotes.list = emotes
     state.emotes.fetching = false
@@ -92,30 +92,21 @@ const component = (state, emit) => {
       const formData = new FormData()
       formData.append('image', image)
 
-      const { path } = await api.postRaw(state, 'upload-image?sessionID=' + state.session.id, formData).catch(error => {
+      const { path: imageURL } = await api.postRaw(state, 'upload-image?sessionID=' + state.session.id, formData).catch(error => {
         modal.showError('Failed to upload image')
         modal.disable(false)
         throw error
       })
 
-      // update the emotes list
-      const emote = { shortcode, imageURL: path }
-
-      const { results } = await api.post(state, 'server-settings', {
-        patch: {
-          emotes: [ ...state.emotes.list, emote ]
-        },
-        sessionID: state.session.id,
-      }).catch(error => {
+      try {
+        await api.post(state, 'emotes', {
+          shortcode, imageURL,
+          sessionID: state.session.id,
+        })
+      } catch (error) {
         modal.showError(error.message)
         modal.disable(false)
         throw error
-      })
-
-      if (results.emotes !== 'updated') {
-        modal.showError('Internal error')
-        modal.disable(false)
-        throw results.emotes
       }
 
       emit('emotes.fetch')
@@ -127,10 +118,7 @@ const component = (state, emit) => {
     const deleteEmote = async () => {
       state.emotes.list = state.emotes.list.filter(e => e.shortcode !== emote.shortcode)
 
-      await api.post(state, 'server-settings', {
-        patch: {
-          emotes: state.emotes.list,
-        },
+      await api.delete(state, 'emotes/' + emote.shortcode, {
         sessionID: state.session.id,
       })
 

--- a/packages/client/src/components/srv-settings/emotes.js
+++ b/packages/client/src/components/srv-settings/emotes.js
@@ -99,10 +99,7 @@ const component = (state, emit) => {
       })
 
       try {
-        await api.post(state, 'emotes', {
-          shortcode, imageURL,
-          sessionID: state.session.id,
-        })
+        await api.post(state, 'emotes', {shortcode, imageURL})
       } catch (error) {
         modal.showError(error.message)
         modal.disable(false)
@@ -117,11 +114,7 @@ const component = (state, emit) => {
   const rows = state.emotes.list.map(emote => {
     const deleteEmote = async () => {
       state.emotes.list = state.emotes.list.filter(e => e.shortcode !== emote.shortcode)
-
-      await api.delete(state, 'emotes/' + emote.shortcode, {
-        sessionID: state.session.id,
-      })
-
+      await api.delete(state, 'emotes/' + emote.shortcode)
       emit('render')
     }
 

--- a/packages/client/src/util/api.js
+++ b/packages/client/src/util/api.js
@@ -15,6 +15,11 @@ async function fetchHelper(state, path, fetchConfig = {}) {
     console.trace()
   }
 
+  if (state.session.id) {
+    fetchConfig.headers = fetchConfig.headers || {}
+    fetchConfig.headers['X-Session-ID'] = state.session.id
+  }
+
   const protocol = secure ? 'https://' : '//'
   const result = await fetch(protocol + host + '/api/' + path, fetchConfig)
     .then(res => res.json())
@@ -42,34 +47,17 @@ function generateQueryString(query) {
 
 module.exports = {
   get(state, path, query = {}) {
-    // Set the session ID if it's set on the state, but only if not already
-    // set by the passed query.
-    if (state.session.id && !query.sessionID) {
-      query.sessionID = state.session.id
-    }
-
     return fetchHelper(state, path + generateQueryString(query))
   },
 
   delete(state, path, query = {}) {
     // DELETE takes a query string, not a body (so, no "POST" data).
-
-    if (state.session.id && !query.sessionID) {
-      query.sessionID = state.session.id
-    }
-
     return fetchHelper(state, path + generateQueryString(query), {
       method: 'delete'
     })
   },
 
   post(state, path, data = {}) {
-    // As with get, set the session ID if it's on the state and issing
-    // from the data object.
-    if (state.session.id && !data.sessionID) {
-      data.sessionID = state.session.id
-    }
-
     return fetchHelper(state, path, {
       method: 'post',
       headers: {
@@ -81,11 +69,6 @@ module.exports = {
 
   patch(state, path, changes = {}) {
     // PATCH takes a body, like POST.
-
-    if (state.session.id && !data.sessionID) {
-      data.sessionID = state.session.id
-    }
-
     return fetchHelper(state, path, {
       method: 'patch',
       headers: {

--- a/packages/client/src/util/modal.js
+++ b/packages/client/src/util/modal.js
@@ -39,8 +39,8 @@ class Modal extends Nanobus {
       const input = el.querySelector('input')
 
       input.addEventListener('keypress', evt => {
-        // listen for enter/return keypress
         if (evt.which === 13) {
+          // enter/return, move to next input or submit
           evt.preventDefault()
 
           // if there's a next input, focus it
@@ -50,6 +50,10 @@ class Modal extends Nanobus {
           } else {
             this.submit()
           }
+        } else if ((evt.which || evt.keyCode) === 27) {
+          // escape, cancel
+          evt.preventDefault()
+          this.close()
         }
       })
     }

--- a/packages/server/api.js
+++ b/packages/server/api.js
@@ -1076,6 +1076,10 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
     })
   })
 
+  app.use('/api/*', (request, response, next) => {
+    response.status(404).json({error: errors.NOT_FOUND})
+  })
+
   wss.on('connection', socket => {
     const socketData = {
       sessionID: null,


### PR DESCRIPTION
The client used to be dead. Now it isn't.

This changes old endpoints in the client's code to new endpoints. I probably missed some, but this is a good start.

Some other things I changed:

* You'll automatically be logged in after registering.

* You'll automatically get kicked out of the account settings page if you log out while in it (e.g. by deleting your current session, or just clicking the "logout" button).

* Holding alt while pressing the up/down arrow keys switches to the channel above or below the current one in the channel list. This loops - if you're on the top channel and press up, it'll move to the bottom one (and vice versa). (Fixes #13.)

* Viewing a channel immediately focuses the message textarea (if you're logged in).

* Pressing escape cancels the active modal. (Fixes #12.)

* Clicking the channel you're already viewing won't reload the channel anymore. (Fixes #139.)

* No more "reset password" section in the account settings. It's always shown a "not implemented" alert, and it's really not necessary to leave it or its code lying around. It's not hard to recover the code when we eventually implement resetting passwords.

* The image upload API works now. I had to change some things on the backend.

* The account settings API also works. More (small) backend changes.

* Pages under `/api/` don't return the client's index.html if they aren't found. (Instead, they return the Express default - which is an HTTP-404 with a "Cannot GET /api/(...)" message).

* I removed a few redundant `sessionID`s being passed in the client. `util/api` automatically adds the session ID.

I've only tested this on a server which does not require authorization.