### PR TITLE
Fix authorization-related errors

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -125,21 +125,25 @@ GET /api/settings
 <- }
 ```
 
-### Modify settings [PATCH /api/settings]
+### Modify settings [POST /api/settings]
 + requires admin session
 + `name` (string; optional)
 + `authorizationMessage` (string; optional)
 
-Returns `{}` if successful. Updates settings with new values provided.
+Returns `{ results }` if successful, where `results` is an object describing the result of each changed setting. Updates settings with new values provided.
 
 ```js
-PATCH /api/settings
+POST /api/settings
 
 -> {
 ->   "name": "My Server"
 -> }
 
-<- {}
+<- {
+<-   "result": {
+<-     "name": "updated"
+<-   }
+<- }
 ```
 
 ---

--- a/packages/client/src/app.js
+++ b/packages/client/src/app.js
@@ -118,7 +118,7 @@ app.use((state, emitter) => {
         break handleHostChange
       }
 
-      const { useSecure, useAuthorization, authorizationMessage } = await api.get(state, 'properties')
+      const { properties: { useSecure, useAuthorization, authorizationMessage } } = await api.get(state, 'properties')
 
       state.serverRequiresAuthorization = useAuthorization
       state.secure = useSecure

--- a/packages/client/src/app.js
+++ b/packages/client/src/app.js
@@ -60,7 +60,6 @@ app.use((state, emitter) => {
       if (key === 'user') {
         if (target.id !== value) {
           state.ws.send('pongdata', { sessionID: value })
-          emitter.emit('sessionuserloaded')
         }
       }
 

--- a/packages/client/src/components/srv-settings/authorized-users.js
+++ b/packages/client/src/components/srv-settings/authorized-users.js
@@ -31,11 +31,11 @@ const store = (state, emitter) => {
 
     state.authorizedUsers.fetching = true
 
-    const { users, unauthorizedUsers } = await api.get(state, 'user-list')
+    const { users, unauthorizedUsers } = await api.get(state, 'users')
     state.authorizedUsers.authorizedList = users
     state.authorizedUsers.unauthorizedList = unauthorizedUsers
 
-    const { authorizationMessage } = await api.get(state, 'settings')
+    const { settings: { authorizationMessage } } = await api.get(state, 'settings')
     state.authorizedUsers.authorizationMessage = authorizationMessage
 
     state.authorizedUsers.fetching = false
@@ -46,8 +46,9 @@ const store = (state, emitter) => {
   emitter.on('authorizedUsers.saveMessage', async () => {
     const authorizationMessage = document.getElementById(`${prefix}message`).value
 
-    await api.patch(state, 'settings', {authorizationMessage})
+    await api.post(state, 'settings', {authorizationMessage})
 
+    state.authorizedUsers.authorizationMessage = authorizationMessage
     state.authorizedUsers.authMessageSaved = true
 
     emitter.emit('render')

--- a/packages/client/src/components/user-list.js
+++ b/packages/client/src/components/user-list.js
@@ -22,7 +22,7 @@ const store = (state, emitter) => {
       return
     }
 
-    if (state.serverRequiresAuthorization && !state.session.id) {
+    if (!state.sessionAuthorized) {
       return
     }
 
@@ -46,9 +46,9 @@ const store = (state, emitter) => {
   // If the user list is fetched before the websocket has properly connected,
   // the API will say that our session's user is not logged in. But it'll emit
   // that we've logged in *before we're even listening for users to come online*,
-  // which means we'll miss that event. We use this "session user loaded" event
-  // as a workaround to deal with that.
-  emitter.on('sessionuserloaded', () => {
+  // which means we'll miss that event. We use this login event (emitted after
+  // the session user is loaded) as a workaround to deal with that.
+  emitter.on('login', () => {
     if (state.session.user) {
       if (state.userList.users) {
         state.userList.users.find(u => u.id === state.session.user.id).online = true

--- a/packages/client/src/util/api.js
+++ b/packages/client/src/util/api.js
@@ -27,6 +27,14 @@ async function fetchHelper(state, path, fetchConfig = {}) {
   // if we get an error object, throw
   if (result.error) {
     // { message, data }
+
+    /*
+    console.log('error ---- ' + result.error.code)
+    console.log('fetch config:', fetchConfig)
+    console.log('sessionid:', state.session.id)
+    console.log('path:', path)
+    */
+
     throw Object.assign(new Error(result.error.message), {
       code: result.error.code,
       data: result,

--- a/packages/client/src/util/api.js
+++ b/packages/client/src/util/api.js
@@ -75,23 +75,12 @@ module.exports = {
     })
   },
 
-  patch(state, path, changes = {}) {
-    // PATCH takes a body, like POST.
-    return fetchHelper(state, path, {
-      method: 'patch',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(data)
-    })
-  },
-
   postRaw(state, path, body) {
     if (!body) return Promise.reject(new Error('Body not provided'))
 
     return fetchHelper(state, path, {
       method: 'post',
-      body,
+      body
     })
   },
 

--- a/packages/server/api.js
+++ b/packages/server/api.js
@@ -105,8 +105,10 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
         [
           ['GET', /^\/$/],
           ['POST', /^\/sessions$/],
+          ['GET', /^\/sessions\//],
           ['POST', /^\/users$/],
           ['GET', /^\/username-available/],
+          ['GET', /^\/properties$/],
         ].find(([ m, re ]) => request.method === m && re.test(request.path))
       )) {
         request[middleware.vars].shouldVerify = true

--- a/packages/server/api.js
+++ b/packages/server/api.js
@@ -316,19 +316,17 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
     }
   ])
 
-  app.patch('/api/settings', [
-    ...middleware.loadVarFromBody('patch'),
+  app.post('/api/settings', [
+    ...middleware.loadSessionID('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
     ...middleware.requireBeAdmin('sessionUser'),
 
     async (request, response) => {
-      const { patch } = request[middleware.vars]
-
       const serverSettings = await db.settings.findOne({_id: serverSettingsID})
 
       const results = {}
 
-      for (const [ key, value ] of Object.entries(patch)) {
+      for (const [ key, value ] of Object.entries(request.body)) {
         results[key] = await setSetting(db.settings, serverSettingsID, key, value)
       }
 


### PR DESCRIPTION
None of these are tracked, but this commit fixes authorization errors on both the client and the server.

It's a major/breaking change for the server (see below), and a patch change for the client (since it just fixes bugs).

* Fixes properties in general not being fetched correctly (on the client). `state.secure`, `state.serverRequiresAuthorization`, and `state.authorizationMessage` now actually work.

* Fixes the user list causing several errors that prevent messages from being loaded and such (mainly because it assumed a non-authorized server).

* Changes PATCH /api/settings to POST /api/settings (this is the breaking change, see below).

Important commit message:

>For some reason, no matter absolutely what, Express wasn't handling PATCH /api/settings. I have no idea why. Changing the method to POST /api/settings fixed it.
>
>I also updated the documentation, now also including information on the "results" return property.