### PR TITLE
Only focus message input once

### DIFF
--- a/packages/client/src/components/message-editor.js
+++ b/packages/client/src/components/message-editor.js
@@ -103,7 +103,7 @@ const component = (state, emit) => {
 
     // Hack!!! - Select the textarea *soon*. We assume that the component is
     // rendered and on the page by 25ms from now.
-    setInterval(() => {
+    setTimeout(() => {
       textarea.focus()
     }, 25)
 


### PR DESCRIPTION
Doing so on an interval was making it impossible to focus on anything else. This was an issue for me when I tried to create a second channel and couldn't type its name.

Obviously this is still a hack and will be changed later anyway, but it's nice to also have it fixed in the short-term.