### PR TITLE
Add user register/leave events, and make user list respond to these

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -901,7 +901,7 @@ Sent to all clients when a user is created, or instead when they are authorized,
 <a name='user-gone'></a>
 ## user/gone
 
-Sent to all clients when a user is deleted, or also when they are deauthorized, if the server [requires authorization](#authorization). Passed data is in the format `{ userID }`.
+Sent to all clients when a user is deleted, or when a user is deauthorized, if the server [requires authorization](#authorization). Passed data is in the format `{ userID }`.
 
 <a name='user-online'></a>
 ## user/online

--- a/docs/api.md
+++ b/docs/api.md
@@ -896,7 +896,12 @@ Sent to all clients when a channel is [deleted](#delete-channel). Passed data is
 <a name='user-new'></a>
 ## user/new
 
-Sent to all clients when a user is created, or instead when they are authorized, if [authorization](#authorization) is required. Passed data is in the format `{ user }`.
+Sent to all clients when a user is created, or instead when they are authorized, if the server [requires authorization](#authorization). Passed data is in the format `{ user }`.
+
+<a name='user-gone'></a>
+## user/gone
+
+Sent to all clients when a user is deleted, or also when they are deauthorized, if the server [requires authorization](#authorization). Passed data is in the format `{ userID }`.
 
 <a name='user-online'></a>
 ## user/online

--- a/docs/api.md
+++ b/docs/api.md
@@ -736,7 +736,7 @@ GET /api/users?sessionID=adminsid123
 + `username` ([name](#names)) - Must be unique
 + `password` (string) - Errors if shorter than 6 characters
 
-Responds with `{ user }` if successful, where `user` is the new user object. Note the given password is passed as a plain string and is stored in the database as a bcrypt-hashed and salted string (and not in any plaintext form). Log in with [POST /api/sessions](#login).
+Responds with `{ user }` if successful, where `user` is the new user object. If the server does not [require authorization](#authorization), [user/new](#user-new) is emitted. Note the given password is passed as a plain string and is stored in the database as a bcrypt-hashed and salted string (and not in any plaintext form). Log in with [POST /api/sessions](#login).
 
 ```js
 POST /api/users
@@ -888,6 +888,11 @@ Sent to all clients when a channel is [renamed](#rename-channel). Passed data is
 ## channel/delete
 
 Sent to all clients when a channel is [deleted](#delete-channel). Passed data is in the format `{ channelID }`.
+
+<a name='user-new'></a>
+## user/new
+
+Sent to all clients when a user is created, or instead when they are authorized, if [authorization](#authorization) is required. Passed data is in the format `{ user }`.
 
 <a name='user-online'></a>
 ## user/online

--- a/packages/client/src/components/user-list.js
+++ b/packages/client/src/components/user-list.js
@@ -89,6 +89,17 @@ const store = (state, emitter) => {
       emitter.emit('render')
     }
   })
+
+  emitter.on('ws.user/gone', data => {
+    if (state.userList.users) {
+      const index = state.userList.users.findIndex(u => u.id === data.userID)
+
+      if (index >= 0) {
+        state.userList.users.splice(index, 1)
+        emitter.emit('render')
+      }
+    }
+  })
 }
 
 const prefixSidebar = css('./sidebar.css')

--- a/packages/client/src/components/user-list.js
+++ b/packages/client/src/components/user-list.js
@@ -64,6 +64,12 @@ const store = (state, emitter) => {
       }
     }
   })
+
+  emitter.on('ws.user/new', data => {
+    if (state.userList.users) {
+      state.userList.users.push(data.user)
+    }
+  })
 }
 
 const prefixSidebar = css('./sidebar.css')

--- a/packages/client/src/components/user-list.js
+++ b/packages/client/src/components/user-list.js
@@ -86,6 +86,7 @@ const store = (state, emitter) => {
   emitter.on('ws.user/new', data => {
     if (state.userList.users) {
       state.userList.users.push(data.user)
+      emitter.emit('render')
     }
   })
 }

--- a/packages/server/api.js
+++ b/packages/server/api.js
@@ -963,9 +963,15 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
     async function(request, response) {
       const { userID } = request[middleware.vars]
 
-      await db.users.update({_id: userID}, {
-        $set: {authorized: true}
-      })
+      if (await db.users.findOne({_id: userID, authorized: false})) {
+        await db.users.update({_id: userID}, {
+          $set: {authorized: true}
+        })
+
+        sendToAllSockets('user/new', {
+          user: await serialize.user(await db.users.findOne({_id: userID}))
+        })
+      }
 
       response.status(200).json({})
     }

--- a/packages/server/api.js
+++ b/packages/server/api.js
@@ -993,9 +993,13 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
         return
       }
 
-      await db.users.update({_id: userID}, {
-        $set: {authorized: false}
-      })
+      if (await db.users.findOne({_id: userID, authorized: true})) {
+        await db.users.update({_id: userID}, {
+          $set: {authorized: false}
+        })
+
+        sendToAllSockets('user/gone', {userID})
+      }
 
       response.status(200).json({})
     }


### PR DESCRIPTION
Fixes #217.

The code and docs here are pretty self-descriptive, but the tl;dr is that there are two new events - `user/new` and `user/gone` - called when a user is created/authorized and deleted/deauthorized, respectively. These events are reflected in the user list sidebar.