### PR TITLE
Use uglify-es instead of tinyify

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -22,18 +22,15 @@
   "devDependencies": {
     "browserify": "^15.1.0",
     "css-extract": "^1.2.0",
-    "dependency-check": "^2.10.0",
-    "pretty-bytes-cli": "^2.0.0",
     "sheetify": "^6.2.0",
     "sheetify-nested": "^1.0.2",
-    "tinyify": "^2.4.0",
     "watchify": "^3.9.0",
+    "uglify-es": "^3.3.9",
     "yo-yoify": "^4.3.0"
   },
   "scripts": {
-    "build": "rm dist/*; browserify src/app.js -o dist/bundle.js -g yo-yoify -t [ sheetify -u sheetify-nested ] -p [ css-extract -o dist/bundle.css ] -p tinyify && cat dist/bundle.js | gzip --best > dist/bundle.js.gz && cat dist/bundle.js.gz | wc -c | pretty-bytes",
-    "watch": "rm dist/*; watchify src/app.js -o dist/bundle.js -d -t [ sheetify -u sheetify-nested ] -p [ css-extract -o dist/bundle.css ] -v",
-    "prepublishOnly": "npm run build",
-    "test": "dependency-check . --entry src/app.js --missing --unused --no-dev -i sheetify"
+    "build": "browserify src/app.js -g yo-yoify -t [ sheetify -u sheetify-nested ] -p [ css-extract -o dist/bundle.css ] | uglifyjs --compress --mangle -o dist/bundle.js",
+    "watch": "watchify src/app.js -o dist/bundle.js -d -t [ sheetify -u sheetify-nested ] -p [ css-extract -o dist/bundle.css ] -v",
+    "prepublishOnly": "npm run build"
   }
 }


### PR DESCRIPTION
Fixes build errors related to tinyify/uglify that kept on occurring, namely on mercury - the https://meta.decent.chat production server!! - and, sometimes, my local machine.

Oh, and I removed `dependency-check` and the `__kb` display after builds too because we don't really need them and nobody likes bloat.

CC @TheInitializer - this removes the `rm dist/*;` part of the build step so it should start working on Windows now, please test.