### PR TITLE
Fetch authorization message on client properly

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -112,6 +112,8 @@ Model:
 ```
 
 ### Retrieve all settings [GET /api/settings]
+* never requires session
+
 Returns `{ settings }`, where `settings` is an object representing server-specific settings.
 
 ```js
@@ -165,6 +167,8 @@ Model:
 ```
 
 ### Retrieve all properties [GET /api/properties]
+* never requires session
+
 Returns `{ properties }`, where `properties` is an object representing server-specific properties.
 
 ```js

--- a/packages/client/src/app.js
+++ b/packages/client/src/app.js
@@ -116,7 +116,8 @@ app.use((state, emitter) => {
         break handleHostChange
       }
 
-      const { properties: { useSecure, useAuthorization, authorizationMessage } } = await api.get(state, 'properties')
+      const { properties: { useSecure, useAuthorization } } = await api.get(state, 'properties')
+      const { settings: { authorizationMessage } } = await api.get(state, 'settings')
 
       state.serverRequiresAuthorization = useAuthorization
       state.secure = useSecure

--- a/packages/server/api.js
+++ b/packages/server/api.js
@@ -109,6 +109,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
           ['POST', /^\/users$/],
           ['GET', /^\/username-available/],
           ['GET', /^\/properties$/],
+          ['GET', /^\/settings$/],
         ].find(([ m, re ]) => request.method === m && re.test(request.path))
       )) {
         request[middleware.vars].shouldVerify = true


### PR DESCRIPTION
This publishes `/api/settings` (so that it doesn't require authorization) and updates the client to fetch the authorization message from the server's settings instead of its properties (which never contained the message in the first place).