### PR TITLE
Change <br> to <br/>

### DIFF
--- a/packages/client/src/components/srv-settings/emotes.js
+++ b/packages/client/src/components/srv-settings/emotes.js
@@ -143,7 +143,7 @@ const component = (state, emit) => {
       </tbody>
     </table>
 
-    <br/>
+    <br>
 
     <div class='submit'>
       <button class='Button' onclick=${addEmote}>Add</button>


### PR DESCRIPTION
Firefox does *not* like it when you try to `createElement('br/')`. This is admittedly a problem that should be fixed in choo, but it's easy enough to quickly change here.