### PR TITLE
Improve flair styling in dark theme

### DIFF
--- a/packages/client/src/components/preferences/appearance.js
+++ b/packages/client/src/components/preferences/appearance.js
@@ -125,6 +125,9 @@ const apply = appearance => {
       '--input-bg': 'var(--gray-100)',
       '--input-border-color': '#3c4144',
       '--input-disabled-bg': '#3c4144',
+
+      '--flair-bg': 'var(--gray-200)',
+      '--flair-fg': 'var(--gray-500)',
     },
   }
 


### PR DESCRIPTION
Changes flair styling (in the dark theme) from this:

![Gray on light gray](https://user-images.githubusercontent.com/9948030/36826346-0ace4502-1ce3-11e8-89ef-56bb9e4f578a.png)

...to this:

![Light gray on gray](https://user-images.githubusercontent.com/9948030/36826356-128ff902-1ce3-11e8-9e52-03966d6d84bc.png)
