### PR TITLE
Fix automatic pongdata so it actually does its thing

### DIFF
--- a/packages/client/src/app.js
+++ b/packages/client/src/app.js
@@ -29,7 +29,6 @@ const app = choo()
 app.use(devtools())
 
 app.use((state, emitter) => {
-  state.session = null // { id, user }
   state.ws = null // WS
   state.secure = false
   state.serverRequiresAuthorization = false
@@ -57,10 +56,11 @@ app.use((state, emitter) => {
 
   state._session = new Proxy({}, {
     set: function(target, key, value) {
+      const oldValue = Reflect.get(target, key)
       const ret = Reflect.set(target, key, value)
 
-      if (key === 'user') {
-        if (target.id !== value) {
+      if (key === 'id') {
+        if (oldValue !== value) {
           state.ws.send('pongdata', { sessionID: value })
         }
       }


### PR DESCRIPTION
Fixes #245.

Two problems were happening here:

* We were checking for `user` changing, instead of `id`. This means that we would respond `pongdata {sessionID: {username: 'florrie'}}`, etc, instead of `pongdata {sessionID: '1234'}`.
* We were checking if the new `value` was different from `target.id`... but of course, this is never true, since we'd just ran `Reflect.set(target, 'id')`! We now keep track of the old value and compare the new value to that.