### PR TITLE
Very simple half-fix for unread messages

### DIFF
--- a/packages/client/src/components/messages.js
+++ b/packages/client/src/components/messages.js
@@ -231,7 +231,11 @@ const store = (state, emitter) => {
         state.messages.scrolledToEnd = true
 
         // We reached the end of the channel - mark it as read.
-        if (state.sessionAuthorized) await api.post(state, `channels/${state.params.channel}/mark-read`)
+        if (state.sessionAuthorized) {
+          await api.post(state, `channels/${state.params.channel}/mark-read`)
+          const channel = state.sidebar.channels.find(c => c.id === state.params.channel)
+          channel.unreadMessageCount = 0
+        }
       }
 
       if (!state.messages.list) {


### PR DESCRIPTION
This PR makes `unreadMessageCount` be set to zero in the sidebar after scrolling to the end of a channel. There are certainly edge-cases - what to do when viewing a channel with so few messages that it is impossible to scroll comes to mind - but those really are edge-cases. This is a quick fix for typical cases (channels with lots of messages).