### PR TITLE
Avoid a few miscellaneous client errors

### DIFF
--- a/packages/client/src/app.js
+++ b/packages/client/src/app.js
@@ -127,6 +127,13 @@ app.use((state, emitter) => {
         break handleHostChange
       }
 
+      if (typeof state.params.host === 'undefined') {
+        state.ws = null
+        state.secure = false
+        state.serverRequiresAuthorization = false
+        break handleHostChange
+      }
+
       const { properties: { useSecure, useAuthorization } } = await api.get(state, 'properties')
       const { settings: { authorizationMessage } } = await api.get(state, 'settings')
 

--- a/packages/client/src/components/sidebar-left.js
+++ b/packages/client/src/components/sidebar-left.js
@@ -420,7 +420,18 @@ const store = (state, emitter) => {
   })
 
   async function loadSessionID(sessionID) {
-    const { user } = await api.get(state, 'sessions/' + sessionID)
+    let response
+    try {
+      response = await api.get(state, 'sessions/' + sessionID)
+    } catch (error) {
+      if (error.code === 'NOT_FOUND') {
+        response = {}
+      } else {
+        throw error
+      }
+    }
+
+    const { user } = response
     if (user) {
       state.session = { id: sessionID, user }
       state.sessionAuthorized = user.authorized

--- a/packages/client/src/components/sidebar-right.js
+++ b/packages/client/src/components/sidebar-right.js
@@ -62,7 +62,10 @@ const store = (state, emitter) => {
   emitter.on('login', () => {
     if (state.session.user) {
       if (state.userList.users) {
-        state.userList.users.find(u => u.id === state.session.user.id).online = true
+        const user = state.userList.users.find(u => u.id === state.session.user.id)
+        if (user) {
+          user.online = true
+        }
       } else if (state.serverRequiresAuthorization) {
         // If the server requires authorization, now is a good time to fetch the
         // user list.


### PR DESCRIPTION
Fixes a few client errors that aren't being tracked. I get that we're working on the preact client, but these are helpful while still developing with the non-preact client.

* No more error when you first open the page (i.e. when the route does not have a `host` parameter). Now the client resets to a "not in server" state, instead of trying to fetch `http://undefined/api/properties`.

* No more error when your user doesn't show up in the user list, for whatever reason.

* No more error when the client automatically restores a session ID, but that session has been deleted. It treats that as you being logged out now.