### PR TITLE
Implement Unix timestamps

### DIFF
--- a/packages/client/src/components/message-group.js
+++ b/packages/client/src/components/message-group.js
@@ -1,7 +1,7 @@
 const raw = require('choo/html/raw')
 const html = require('choo/html')
 const { svg, mrk, api } = require('../util')
-const { timeAgo } = require('../util/date')
+const { asJSDate, timeAgo } = require('../util/date')
 
 // times are updated outside of choo because we don't need to
 // diff the entire tree just to modify times
@@ -52,12 +52,12 @@ const component = (state, emit, group, { withActions = true, showFlair = true, m
     await api.delete(state, `messages/${msg.id}`)
   }
 
-  const timeEl = date => {
-    const { needsUpdate, string } = timeAgo(date)
+  const timeEl = unixDate => {
+    const { needsUpdate, string } = timeAgo(unixDate)
 
     return html`<time class=${needsUpdate ? 'needs-update': ''}
-         title=${new Date(date).toLocaleString()}
-         data-date=${date.toString()}>
+         title=${new Date(asJSDate(unixDate)).toLocaleString()}
+         data-date=${unixDate.toString()}>
       ${string}
     </time>`
   }

--- a/packages/client/src/util/date.js
+++ b/packages/client/src/util/date.js
@@ -1,4 +1,4 @@
-const second = 1000
+const second = 1
 const minute = 60 * second
 const hour = 60 * minute
 const day = 24 * hour
@@ -7,16 +7,21 @@ const week = 7 * day
 // returns 3-character month name from a Date
 const month = d => [ 'Jan', 'Feb',' Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ][d.getMonth()]
 
+const asUnixDate = jsDate => Math.floor(jsDate / 1000)
+const asJSDate = unixDate => unixDate * 1000
+const unixDateNow = () => asUnixDate(Date.now())
+Object.assign(module.exports, {asUnixDate, asJSDate, unixDateNow})
+
 // converts a milliseconds-date-number to a readable string
 // * < 60sec: just now
 // * < 30min: X mins (or 1 min)
 // * < 24hrs: X hours (or 1 hour) -- rounded, not floored
 // * > 24hrs: X days (or 1 day)
 // * > 7days: date (e.g. Apr 2)
-module.exports.timeAgo = function (date) {
+module.exports.timeAgo = function (unixDate) {
   const s = (t, n) => n + ' ' + t + (n === 1 ? '' : 's')
 
-  const ago = Date.now() - date
+  const ago = unixDateNow() - unixDate
 
   if (ago < minute) {
     return { needsUpdate: true, string: 'Just now' }
@@ -31,7 +36,7 @@ module.exports.timeAgo = function (date) {
   }
 
   if (ago > week) {
-    const d = new Date(date)
+    const d = new Date(asJSDate(unixDate))
     return { needsUpdate: false, string: `${month(d)} ${d.getDate()}` }
   }
 

--- a/packages/server/api.js
+++ b/packages/server/api.js
@@ -31,6 +31,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
   const serialize = makeSerializers({db, util})
 
   const {
+    asUnixDate, unixDateNow,
     getUserIDBySessionID,
     getUserBySessionID,
     emailToAvatarURL,
@@ -125,7 +126,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
   const markChannelAsRead = async function(userObj, channelID, emitEvent = true) {
     await db.users.update({_id: userObj._id}, {
       $set: {
-        [`lastReadChannelDates.${channelID}`]: Date.now()
+        [`lastReadChannelDates.${channelID}`]: unixDateNow()
       }
     })
 
@@ -433,7 +434,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
         authorEmail: sessionUser.email,
         authorFlair: sessionUser.flair,
         text: request.body.text,
-        date: Date.now() - 1,
+        date: unixDateNow() - 1,
         editDate: null,
         channelID: channelID,
         reactions: {}
@@ -525,7 +526,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
       const [ numAffected, newMessage ] = await db.messages.update({_id: oldMessage._id}, {
         $set: {
           text,
-          editDate: Date.now()
+          editDate: unixDateNow()
         }
       }, {
         multi: false,
@@ -1263,7 +1264,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
         const session = await db.sessions.insert({
           _id: uuidv4(),
           userID: user._id,
-          dateCreated: Date.now()
+          dateCreated: unixDateNow()
         })
 
         response.status(200).json({
@@ -1462,7 +1463,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
 
     await db.sessions.remove({
       $where: function() {
-        return Date.now() - this.dateCreated > maximumLifetime
+        return unixDateNow() - this.dateCreated > maximumLifetime
       }
     }, {multi: true})
   }

--- a/packages/server/common.js
+++ b/packages/server/common.js
@@ -11,6 +11,9 @@ module.exports = function makeCommonUtils({db, connectedSocketsMap}) {
   // regex can be updated.
   const isNameValid = name => /^[a-zA-Z0-9_-]+$/g.test(name)
 
+  const asUnixDate = jsDate => Math.floor(jsDate / 1000)
+  const unixDateNow = () => asUnixDate(Date.now())
+
   const getUserIDBySessionID = async function(sessionID) {
     if (!sessionID) {
       return null
@@ -188,6 +191,7 @@ module.exports = function makeCommonUtils({db, connectedSocketsMap}) {
 
   return {
     isNameValid,
+    asUnixDate, unixDateNow,
     getUserIDBySessionID, getUserBySessionID,
     md5,
     isUserOnline, isUserAuthorized,


### PR DESCRIPTION
Towards #281. This makes dates generally be stored as Unix timestamps, as per the 1.0.0 specification. It also updates the client to deal with this. (Conveniently, changing `second = 1000` to `second = 1` did half the work automatically!)