### PR TITLE
Add basic type property to messages

### DIFF
--- a/packages/server/api.js
+++ b/packages/server/api.js
@@ -432,6 +432,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
         authorUsername: sessionUser.username,
         authorEmail: sessionUser.email,
         authorFlair: sessionUser.flair,
+        type: 'user',
         text: request.body.text,
         date: Date.now() - 1,
         editDate: null,

--- a/packages/server/serialize.js
+++ b/packages/server/serialize.js
@@ -11,6 +11,7 @@ module.exports = function makeSerializers({util, db}) {
       authorID: m.authorID,
       authorFlair: m.authorFlair || '',
       authorAvatarURL: emailToAvatarURL(m.authorEmail || m.authorID),
+      type: m.type,
       text: m.text,
       date: m.date,
       editDate: m.editDate,

--- a/packages/server/test/serialize.js
+++ b/packages/server/test/serialize.js
@@ -15,6 +15,7 @@ test('serialize.message', t => {
       authorID: '234',
       authorUsername: 'jen',
       authorFlair: 'spooks',
+      type: 'user',
       text: 'Hello!',
       date, editDate,
       channelID: '345',
@@ -23,12 +24,13 @@ test('serialize.message', t => {
 
     const serialized = await serialize.message(message)
 
-    t.deepEqual(Object.keys(serialized), ['id', 'authorUsername', 'authorID', 'authorFlair', 'authorAvatarURL', 'text', 'date', 'editDate', 'channelID', 'reactions', 'mentionedUserIDs'])
+    t.deepEqual(Object.keys(serialized), ['id', 'authorUsername', 'authorID', 'authorFlair', 'authorAvatarURL', 'type', 'text', 'date', 'editDate', 'channelID', 'reactions', 'mentionedUserIDs'])
     t.is(serialized.id, '123')
     t.is(serialized.authorUsername, 'jen')
     t.is(serialized.authorID, '234')
     t.is(serialized.authorFlair, 'spooks')
     t.is(typeof serialized.authorAvatarURL, 'string')
+    t.is(serialized.type, 'user')
     t.is(serialized.text, 'Hello!')
     t.is(serialized.date, date)
     t.is(serialized.editDate, editDate)


### PR DESCRIPTION
Towards #281. All messages have a type property that is `"user"`, for now. System-messages can be implemented later and are not a blocker for continuing general work. It'll be best to do them after permissions are implemented.