### PR TITLE
Implement 1.0.0-spec settings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -198,7 +198,7 @@ This endpoint may return [an error](#errors), namely FAILED, NO, or NOT_ALLOWED.
 ```js
 {
   "name": string,
-  "iconPath": string,
+  "iconURL": string,
 }
 ```
 
@@ -222,7 +222,7 @@ GET /api/settings
 <- {
 <-   "settings": {
 <-     "name": "Unnamed Decent chat server",
-<-     "iconPath": "/uploads/..."
+<-     "iconURL": "https://meta.decent.chat/uploads/..."
 <-   }
 <- }
 ```
@@ -230,7 +230,7 @@ GET /api/settings
 ### Modify settings [PATCH /api/settings]
 + requires [permission](#permissions): `manageServer`
 + `name` (string; optional)
-+ `iconPath` (string; optional)
++ `iconURL` (string; optional)
 
 Returns `{}` if successful. Updates settings with new values provided, and emits [server-settings/update](#server-settings-update).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -198,7 +198,7 @@ This endpoint may return [an error](#errors), namely FAILED, NO, or NOT_ALLOWED.
 ```js
 {
   "name": string,
-  "iconURL": string,
+  "iconPath": string,
 }
 ```
 
@@ -222,7 +222,7 @@ GET /api/settings
 <- {
 <-   "settings": {
 <-     "name": "Unnamed Decent chat server",
-<-     "iconURL": "https://meta.decent.chat/uploads/..."
+<-     "iconPath": "/uploads/..."
 <-   }
 <- }
 ```
@@ -230,7 +230,7 @@ GET /api/settings
 ### Modify settings [PATCH /api/settings]
 + requires [permission](#permissions): `manageServer`
 + `name` (string; optional)
-+ `iconURL` (string; optional)
++ `iconPath` (string; optional)
 
 Returns `{}` if successful. Updates settings with new values provided, and emits [server-settings/update](#server-settings-update).
 

--- a/packages/client/src/app.js
+++ b/packages/client/src/app.js
@@ -134,15 +134,11 @@ app.use((state, emitter) => {
         break handleHostChange
       }
 
-      const { properties: { useSecure, useAuthorization } } = await api.get(state, 'properties')
+      const { useSecureProtocol } = await api.get(state, '/')
       const { settings: { authorizationMessage } } = await api.get(state, 'settings')
 
-      state.serverRequiresAuthorization = useAuthorization
-      state.secure = useSecure
-
-      if (useAuthorization) {
-        state.authorizationMessage = authorizationMessage
-      }
+      state.serverRequiresAuthorization = false
+      state.secure = useSecureProtocol
 
       state.ws = new util.WS(state.params.host, state.secure)
 

--- a/packages/client/src/util/api.js
+++ b/packages/client/src/util/api.js
@@ -6,6 +6,9 @@ async function fetchHelper(state, path, fetchConfig = {}) {
   if (!state) throw new Error('No state argument given')
   if (!path) throw new Error('No path argument given')
 
+  // Let '/' be passed to target the root path (/api).
+  if (path === '/') path = ''
+
   let secure = false, host = state
   if (typeof state === 'object') {
     secure = state.secure

--- a/packages/server/api.js
+++ b/packages/server/api.js
@@ -230,9 +230,13 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
     }
   ])
 
-  app.get('/api/', (request, response) => {
+  app.get('/api/', async (request, response) => {
+    const { https } = await getAllSettings(db.settings, serverPropertiesID)
+
     response.status(200).json({
-      decentVersion: packageObj.version
+      implementation: '@decent/server',
+      decentVersion: packageObj.version,
+      useSecureProtocol: https === 'on'
     })
   })
 
@@ -408,20 +412,6 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
       })
 
       response.status(status).json({results})
-    }
-  ])
-
-  app.get('/api/properties', [
-    async (request, response) => {
-      const { https } = await db.settings.findOne({_id: serverPropertiesID})
-      const useAuthorization = await shouldUseAuthorization()
-
-      response.status(200).json({
-        properties: {
-          useSecure: https === 'on',
-          useAuthorization
-        }
-      })
     }
   ])
 

--- a/packages/server/api.js
+++ b/packages/server/api.js
@@ -15,7 +15,7 @@ const packageObj = require('./package.json')
 const mkdir = util.promisify(fs.mkdir)
 
 const {
-  serverSettingsID, serverPropertiesID, setSetting,
+  serverSettingsID, serverPropertiesID, setSetting, getAllSettings
 } = require('./settings')
 const errors = require('./errors')
 
@@ -384,7 +384,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
     }
   ])
 
-  app.post('/api/settings', [
+  app.patch('/api/settings', [
     ...middleware.loadSessionID('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
     ...middleware.requireBeAdmin('sessionUser'),
@@ -394,11 +394,20 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
 
       const results = {}
 
+      let status = 200
       for (const [ key, value ] of Object.entries(request.body)) {
-        results[key] = await setSetting(db.settings, serverSettingsID, key, value)
+        const result = await setSetting(db.settings, serverSettingsID, key, value)
+        if (result !== 'updated') {
+          results[key] = result
+          status = 400
+        }
       }
 
-      response.status(200).json({results})
+      sendToAllSockets('server-settings/update', {
+        settings: await getAllSettings(serverSettingsID)
+      })
+
+      response.status(status).json({results})
     }
   ])
 

--- a/packages/server/settings.js
+++ b/packages/server/settings.js
@@ -11,6 +11,18 @@ const defaultSettings = {
     // The name of the server.
     name: {value: 'Unnamed Decent chat server'},
 
+    // The path to the server icon. This is always appended to the hostname
+    // of the server, and should usually be set to an image upload path.
+    iconPath: {
+      value: '',
+
+      validationFn: string => {
+        if (typeof string !== 'string') {
+          throw 'not a string'
+        }
+      }
+    },
+
     // Authorization message displayed to users who are logged in but not
     // authorized to participate in the server. Must be less than 800
     // characters long, and supports Markdown.
@@ -96,6 +108,10 @@ module.exports.setSetting = async function(settingsDB, categoryID, key, value) {
   })
 
   return 'updated'
+}
+
+module.exports.getAllSettings = async function(settingsDB, categoryID) {
+  return await settingsDB.findOne({_id: categoryID}, {_id: false})
 }
 
 Object.assign(module.exports, {

--- a/packages/server/settings.js
+++ b/packages/server/settings.js
@@ -11,11 +11,9 @@ const defaultSettings = {
     // The name of the server.
     name: {value: 'Unnamed Decent chat server'},
 
-    // The path to the server icon. This is always appended to the hostname
-    // of the server, and should usually be set to an image upload path.
-    iconPath: {
+    // The URL to the server icon.
+    iconURL: {
       value: '',
-
       validationFn: string => {
         if (typeof string !== 'string') {
           throw 'not a string'

--- a/packages/server/test/api-misc.js
+++ b/packages/server/test/api-misc.js
@@ -1,13 +1,22 @@
 const { test } = require('ava')
 const { testWithServer } = require('./_serverUtil')
 const fetch = require('./_fetch')
+const { setSetting, serverPropertiesID } = require('../settings')
 
 let portForApiMiscTests = 25000
 
-test('/get', t => {
-  return testWithServer(portForApiMiscTests++, async ({ port }) => {
+test('GET /', t => {
+  return testWithServer(portForApiMiscTests++, async ({ server, port }) => {
     const response = await fetch(port, '')
-    t.deepEqual(Object.keys(response), ['decentVersion'])
+    t.deepEqual(Object.keys(response), ['implementation', 'decentVersion', 'useSecureProtocol'])
+
+    t.is(response.implementation, '@decent/server')
     t.is(typeof response.decentVersion, 'string')
+    t.is(response.useSecureProtocol, false)
+
+    await setSetting(server.db.settings, serverPropertiesID, 'https', 'on')
+
+    const response2 = await fetch(port, '')
+    t.is(response2.useSecureProtocol, true)
   })
 })


### PR DESCRIPTION
This generally updates settings to follow the 1.0.0 specification.

* Changes `POST /api/settings` to `PATCH /api/settings`.
* Implements `server-settings/updated { settings }`.
* Removes `GET /api/properties`.
* Adds `useSecureProtocol` field to `/api`. (Also adds tests for this.)
* Makes minor changes to the client to handle these.