### PR TITLE
1.0.0 impl: various datetime fixes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -334,7 +334,7 @@ DELETE /api/emotes/package
 ```js
 {
   "id": string,
-  "dateCreated": number // Unix time at creation
+  "dateCreated": float // Unix time at creation. May be more accurate using decimal places
 }
 ```
 
@@ -436,9 +436,9 @@ DELETE /api/sessions/12345678-ABCDEFGH
   "authorAvatarURL": string,
 
   // Dates are returned as the number of seconds since UTC 1970-1-1, commonly
-  // known as Unix time.
-  "dateCreated": number,
-  "dateEdited": number | null,
+  // known as Unix time. May be more accurate using decimal places.
+  "dateCreated": float,
+  "dateEdited": float | null,
 
   "pinned": boolean,
   "mentionedUserIDs": [ ID ]
@@ -1005,7 +1005,7 @@ GET /api/users/1
 + `limit` (int <= 50; default `50`) - The maximum number of mentions to fetch.
 + `skip` (int; default `0`) - Skips the first n mentions before returning
 
-Returns `{ mentions }`, where `mentions` is an array of [messages](#messages). Note that mentions are sorted by date: `mentions[0]` is the most recent mention.
+Returns `{ mentions }`, where `mentions` is an array of [messages](#messages). Note that mentions are sorted by creation date: `mentions[0]` is the most recent mention.
 
 Combining `limit` and `skip` can net you simple pagination.
 

--- a/packages/server/api.js
+++ b/packages/server/api.js
@@ -434,8 +434,8 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
         authorFlair: sessionUser.flair,
         type: 'user',
         text: request.body.text,
-        date: unixDateNow() - 1,
-        editDate: null,
+        dateCreated: unixDateNow() - 1,
+        dateEdited: null,
         channelID: channelID,
         reactions: {}
       })
@@ -526,7 +526,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
       const [ numAffected, newMessage ] = await db.messages.update({_id: oldMessage._id}, {
         $set: {
           text,
-          editDate: unixDateNow()
+          dateEdited: unixDateNow()
         }
       }, {
         multi: false,
@@ -765,27 +765,27 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
       const query = {channelID}
 
       if (beforeMessage || afterMessage) {
-        query.date = {}
+        query.dateCreated = {}
 
         if (beforeMessage) {
-          query.date.$lt = beforeMessage.date
+          query.dateCreated.$lt = beforeMessage.dateCreated
         }
 
         if (afterMessage) {
-          query.date.$gt = afterMessage.date
+          query.dateCreated.$gt = afterMessage.dateCreated
         }
       }
 
-      const sort = {date: -1}
+      const sort = {dateCreated: -1}
 
       if (afterMessage) {
-        sort.date = +1
+        sort.dateCreated = +1
       }
 
-      // We sort the messages by NEWEST date ({date: -1}), so that we're returned
-      // the newest messages, but then we reverse the array, so that the actual
-      // data returned from the API is sorted by oldest first. (This is so that
-      // appending message elements is easier.)
+      // We sort the messages by NEWEST creation date ({dateCreated: -1}), so
+      // that we're returned the newest messages, but then we reverse the array,
+      // therefore the data returned from the API is sorted by oldest first.
+      // (This is so that appending message elements is easier.)
 
       // TODO: If there is more than 50, show that somehow.
       // TODO: Store 50 as a constant somewhere?
@@ -793,7 +793,7 @@ module.exports = async function attachAPI(app, {wss, db, dbDir}) {
       cursor.sort(sort)
       cursor.limit(limit ? Math.max(1, Math.min(50, parseInt(limit))) : 50)
       const messages = await cursor.exec()
-      if (sort.date === -1) {
+      if (sort.dateCreated === -1) {
         messages.reverse()
       }
 

--- a/packages/server/common.js
+++ b/packages/server/common.js
@@ -93,7 +93,7 @@ module.exports = function makeCommonUtils({db, connectedSocketsMap}) {
     }
 
     const cursor = db.messages.ccount({
-      date: {$gt: date},
+      dateCreated: {$gt: date},
       channelID
     }).limit(200)
     const count = await cursor.exec()
@@ -111,7 +111,7 @@ module.exports = function makeCommonUtils({db, connectedSocketsMap}) {
     }
 
     const message = await db.messages.findOne({
-      date: {$gt: date},
+      dateCreated: {$gt: date},
       channelID
     })
 

--- a/packages/server/common.js
+++ b/packages/server/common.js
@@ -11,7 +11,7 @@ module.exports = function makeCommonUtils({db, connectedSocketsMap}) {
   // regex can be updated.
   const isNameValid = name => /^[a-zA-Z0-9_-]+$/g.test(name)
 
-  const asUnixDate = jsDate => Math.floor(jsDate / 1000)
+  const asUnixDate = jsDate => jsDate / 1000
   const unixDateNow = () => asUnixDate(Date.now())
 
   const getUserIDBySessionID = async function(sessionID) {

--- a/packages/server/serialize.js
+++ b/packages/server/serialize.js
@@ -13,8 +13,8 @@ module.exports = function makeSerializers({util, db}) {
       authorAvatarURL: emailToAvatarURL(m.authorEmail || m.authorID),
       type: m.type,
       text: m.text,
-      dateCreated: m.dateCreated,
-      dateEdited: m.dateEdited,
+      dateCreated: Math.floor(m.dateCreated),
+      dateEdited: m.dateEdited ? Math.floor(m.dateEdited) : null,
       channelID: m.channelID,
       reactions: m.reactions,
       mentionedUserIDs: await util.getMentionsFromMessageContent(m.text),
@@ -49,7 +49,7 @@ module.exports = function makeSerializers({util, db}) {
 
     session: async s => ({
       id: s._id,
-      dateCreated: s.dateCreated
+      dateCreated: Math.floor(s.dateCreated),
     }),
 
     channel: async (c, sessionUser = null) => {

--- a/packages/server/serialize.js
+++ b/packages/server/serialize.js
@@ -13,8 +13,8 @@ module.exports = function makeSerializers({util, db}) {
       authorAvatarURL: emailToAvatarURL(m.authorEmail || m.authorID),
       type: m.type,
       text: m.text,
-      date: m.date,
-      editDate: m.editDate,
+      dateCreated: m.dateCreated,
+      dateEdited: m.dateEdited,
       channelID: m.channelID,
       reactions: m.reactions,
       mentionedUserIDs: await util.getMentionsFromMessageContent(m.text),
@@ -30,8 +30,8 @@ module.exports = function makeSerializers({util, db}) {
         online: isUserOnline(u._id),
         mentions: (await Promise.all((u.mentionedInMessageIDs || []).map(async msgID => await serialize.message(await db.messages.findOne({_id: msgID}), sessionUser)))).sort((a, b) => {
           // Sort by latest edited/created first.
-          if ((a.editDate || a.date) > (b.editDate || b.date)) return -1
-          if ((a.editDate || a.date) < (b.editDate || b.date)) return +1
+          if ((a.dateEdited || a.dateCreated) > (b.dateEdited || b.dateCreated)) return -1
+          if ((a.dateEdited || a.dateCreated) < (b.dateEdited || b.dateCreated)) return +1
           return 0
         }),
       }

--- a/packages/server/serialize.js
+++ b/packages/server/serialize.js
@@ -13,8 +13,8 @@ module.exports = function makeSerializers({util, db}) {
       authorAvatarURL: emailToAvatarURL(m.authorEmail || m.authorID),
       type: m.type,
       text: m.text,
-      dateCreated: Math.floor(m.dateCreated),
-      dateEdited: m.dateEdited ? Math.floor(m.dateEdited) : null,
+      dateCreated: m.dateCreated,
+      dateEdited: m.dateEdited || null,
       channelID: m.channelID,
       reactions: m.reactions,
       mentionedUserIDs: await util.getMentionsFromMessageContent(m.text),
@@ -49,7 +49,7 @@ module.exports = function makeSerializers({util, db}) {
 
     session: async s => ({
       id: s._id,
-      dateCreated: Math.floor(s.dateCreated),
+      dateCreated: s.dateCreated,
     }),
 
     channel: async (c, sessionUser = null) => {

--- a/packages/server/test/api-messages.js
+++ b/packages/server/test/api-messages.js
@@ -51,7 +51,7 @@ test('PATCH /api/messages/:id', t => {
 
     const { message: messageOld } = await fetch(port, '/messages/' + messageID)
     t.is(messageOld.text, 'hello')
-    t.is(messageOld.editDate, null)
+    t.is(messageOld.dateEdited, null)
 
     const response = await fetch(port, '/messages/' + messageID, {
       method: 'PATCH',
@@ -63,7 +63,7 @@ test('PATCH /api/messages/:id', t => {
 
     const { message: messageNew } = await fetch(port, '/messages/' + messageID)
     t.is(messageNew.text, 'goodbye')
-    t.is(typeof messageNew.editDate, 'number')
+    t.is(typeof messageNew.dateEdited, 'number')
 
     const { sessionID: sessionID2 } = await makeUser(server, port)
     try {

--- a/packages/server/test/common.js
+++ b/packages/server/test/common.js
@@ -114,7 +114,7 @@ test('getUnreadMessageCountInChannel', t => {
     t.is(await util.getUnreadMessageCountInChannel(user, channelID), 2)
 
     await Promise.all(new Array(210).fill(0).map(() =>
-      server.db.messages.insert({date: Date.now(), channelID})
+      server.db.messages.insert({dateCreated: Date.now(), channelID})
     ))
     t.is(await util.getUnreadMessageCountInChannel(user, channelID), 200)
   })

--- a/packages/server/test/serialize.js
+++ b/packages/server/test/serialize.js
@@ -7,7 +7,7 @@ let portForSerializeTests = 23000
 
 test('serialize.message', t => {
   return testWithServer(portForSerializeTests++, async ({ serialize }) => {
-    const dateCreated = Math.floor(Date.now() / 1000), dateEdited = dateCreated - 5
+    const dateCreated = Date.now() / 1000, dateEdited = dateCreated - 5
     const reactions = {} // TODO: Actually check how reactions are serialized.
 
     const message = {
@@ -32,8 +32,8 @@ test('serialize.message', t => {
     t.is(typeof serialized.authorAvatarURL, 'string')
     t.is(serialized.type, 'user')
     t.is(serialized.text, 'Hello!')
-    t.is(serialized.dateCreated, dateCreated)
-    t.is(serialized.dateEdited, dateEdited)
+    t.is(serialized.dateCreated, Math.floor(dateCreated))
+    t.is(serialized.dateEdited, Math.floor(dateEdited))
     t.is(serialized.channelID, '345')
     t.deepEqual(serialized.mentionedUserIDs, [])
     t.deepEqual(serialized.reactions, reactions)
@@ -96,13 +96,13 @@ test('serialize.session', t => {
   return testWithServer(portForSerializeTests++, async ({ serialize, server, port }) => {
     const { user, sessionID } = await makeUser(server, port)
 
-    const dateCreated = Date.now()
+    const dateCreated = Date.now() / 1000
     const session = {_id: sessionID, dateCreated, userID: user._id}
     const serialized = await serialize.session(session)
 
     t.deepEqual(Object.keys(serialized), ['id', 'dateCreated'])
     t.is(serialized.id, sessionID)
-    t.is(serialized.dateCreated, dateCreated)
+    t.is(serialized.dateCreated, Math.floor(dateCreated))
   })
 })
 

--- a/packages/server/test/serialize.js
+++ b/packages/server/test/serialize.js
@@ -7,7 +7,7 @@ let portForSerializeTests = 23000
 
 test('serialize.message', t => {
   return testWithServer(portForSerializeTests++, async ({ serialize }) => {
-    const date = Date.now(), editDate = date - 5000
+    const dateCreated = Math.floor(Date.now() / 1000), dateEdited = dateCreated - 5
     const reactions = {} // TODO: Actually check how reactions are serialized.
 
     const message = {
@@ -17,14 +17,14 @@ test('serialize.message', t => {
       authorFlair: 'spooks',
       type: 'user',
       text: 'Hello!',
-      date, editDate,
+      dateCreated, dateEdited,
       channelID: '345',
       reactions
     }
 
     const serialized = await serialize.message(message)
 
-    t.deepEqual(Object.keys(serialized), ['id', 'authorUsername', 'authorID', 'authorFlair', 'authorAvatarURL', 'type', 'text', 'date', 'editDate', 'channelID', 'reactions', 'mentionedUserIDs'])
+    t.deepEqual(Object.keys(serialized), ['id', 'authorUsername', 'authorID', 'authorFlair', 'authorAvatarURL', 'type', 'text', 'dateCreated', 'dateEdited', 'channelID', 'reactions', 'mentionedUserIDs'])
     t.is(serialized.id, '123')
     t.is(serialized.authorUsername, 'jen')
     t.is(serialized.authorID, '234')
@@ -32,8 +32,8 @@ test('serialize.message', t => {
     t.is(typeof serialized.authorAvatarURL, 'string')
     t.is(serialized.type, 'user')
     t.is(serialized.text, 'Hello!')
-    t.is(serialized.date, date)
-    t.is(serialized.editDate, editDate)
+    t.is(serialized.dateCreated, dateCreated)
+    t.is(serialized.dateEdited, dateEdited)
     t.is(serialized.channelID, '345')
     t.deepEqual(serialized.mentionedUserIDs, [])
     t.deepEqual(serialized.reactions, reactions)

--- a/packages/server/test/serialize.js
+++ b/packages/server/test/serialize.js
@@ -32,8 +32,8 @@ test('serialize.message', t => {
     t.is(typeof serialized.authorAvatarURL, 'string')
     t.is(serialized.type, 'user')
     t.is(serialized.text, 'Hello!')
-    t.is(serialized.dateCreated, Math.floor(dateCreated))
-    t.is(serialized.dateEdited, Math.floor(dateEdited))
+    t.is(serialized.dateCreated, dateCreated)
+    t.is(serialized.dateEdited, dateEdited)
     t.is(serialized.channelID, '345')
     t.deepEqual(serialized.mentionedUserIDs, [])
     t.deepEqual(serialized.reactions, reactions)
@@ -102,7 +102,7 @@ test('serialize.session', t => {
 
     t.deepEqual(Object.keys(serialized), ['id', 'dateCreated'])
     t.is(serialized.id, sessionID)
-    t.is(serialized.dateCreated, Math.floor(dateCreated))
+    t.is(serialized.dateCreated, dateCreated)
   })
 })
 


### PR DESCRIPTION
* Updated message datetime keys as per spec (more consistent with the rest of the API):
  * `message.date` -> `message.dateCreated`
  * `message.editDate` -> `message.dateEdited`
  * Updates tests to reflect
* Fix #297 
  - We now store dates to millisecond-level accuracy, however the serialize functions floor the value before they are outputted by the API.
    + This fixes some tests.
  - We may want to get the spec to specify whether these dates should always be integers (what we're doing now) or may be floats.
  - Note that currently the API specifies "number" as the type. This is ambiguous, and we should probably use 'integer' and 'float' across the entire spec if applicable.